### PR TITLE
make partition key configurable and use deviceid from metadata

### DIFF
--- a/dynamicconfig.go
+++ b/dynamicconfig.go
@@ -84,7 +84,7 @@ func (dc *DynamicConfig) matches(msg *wrp.Message) ([]Topic, []TopicShardStrateg
 		}
 
 		// Success
-		topics = append(topics, Topic{Name: topic.Name, Key: topic.Key})
+		topics = append(topics, topic)
 		shardStrategy = append(shardStrategy, route.TopicShardStrategy)
 	}
 

--- a/dynamicconfig.go
+++ b/dynamicconfig.go
@@ -37,10 +37,10 @@ type DynamicConfig struct {
 	Acks Acks
 }
 
-func (dc *DynamicConfig) match(msg *wrp.Message) (string, TopicShardStrategy, error) {
+func (dc *DynamicConfig) match(msg *wrp.Message) (Topic, TopicShardStrategy, error) {
 	locator, err := wrp.ParseLocator(msg.Destination)
 	if err != nil {
-		return "", TopicShardNone, errors.Join(ErrValidation, err)
+		return Topic{}, TopicShardNone, errors.Join(ErrValidation, err)
 	}
 
 	for _, route := range dc.TopicMap {
@@ -49,8 +49,8 @@ func (dc *DynamicConfig) match(msg *wrp.Message) (string, TopicShardStrategy, er
 		}
 
 		topic := route.selectTopic(msg)
-		if topic == "" {
-			return "", route.TopicShardStrategy,
+		if topic.Name == "" {
+			return Topic{}, route.TopicShardStrategy,
 				errors.New("no topic selected for message")
 		}
 
@@ -58,14 +58,14 @@ func (dc *DynamicConfig) match(msg *wrp.Message) (string, TopicShardStrategy, er
 		return topic, route.TopicShardStrategy, nil
 	}
 
-	return "", TopicShardNone, errors.Join(
+	return Topic{}, TopicShardNone, errors.Join(
 		ErrNoTopicMatch,
 		fmt.Errorf("no topic route matched for event type '%s'", locator.Authority),
 	)
 }
 
-func (dc *DynamicConfig) matches(msg *wrp.Message) ([]string, []TopicShardStrategy, error) {
-	var topics []string
+func (dc *DynamicConfig) matches(msg *wrp.Message) ([]Topic, []TopicShardStrategy, error) {
+	var topics []Topic
 	var shardStrategy []TopicShardStrategy
 
 	locator, err := wrp.ParseLocator(msg.Destination)
@@ -79,12 +79,12 @@ func (dc *DynamicConfig) matches(msg *wrp.Message) ([]string, []TopicShardStrate
 		}
 
 		topic := route.selectTopic(msg)
-		if topic == "" {
+		if topic.Name == "" {
 			return nil, nil, errors.New("no topic selected for message")
 		}
 
 		// Success
-		topics = append(topics, topic)
+		topics = append(topics, Topic{Name: topic.Name, Key: topic.Key})
 		shardStrategy = append(shardStrategy, route.TopicShardStrategy)
 	}
 

--- a/hash_key_provider.go
+++ b/hash_key_provider.go
@@ -25,6 +25,11 @@ const (
 )
 
 // HashKeyType represents the type of hash key to extract from a WRP message.
+type HashKey struct {
+	Name          HashKeyType
+	MetadataField string
+}
+
 type HashKeyType string
 
 const (
@@ -38,27 +43,28 @@ const (
 	HashKeyNone HashKeyType = "none"
 )
 
-// ParseHashKeyType converts a string to a HashKeyType.
+// ParseHashKey converts a string to a HashKey.
 // The comparison is case-insensitive.
 // Defaults to metadata/hw-deviceid when the input string is empty.
 // Returns an error if the hash key type is not recognized.
-func ParseHashKeyType(s string) (HashKeyType, string, error) {
+func ParseHashKey(s string) (HashKey, error) {
 	if s == "" {
-		return HashKeyMetadata, DefaultMetadataKeyField, nil
+		return HashKey{Name: HashKeyMetadata,
+			MetadataField: DefaultMetadataKeyField}, nil
 	}
 	tokens := strings.Split(s, "/")
 	switch strings.ToLower(tokens[0]) {
 	case string(HashKeyNone):
-		return HashKeyNone, "", nil
+		return HashKey{Name: HashKeyNone}, nil
 	case string(HashKeyMetadata):
 		if (len(tokens) >= 2) && tokens[1] != "" {
-			return HashKeyMetadata, tokens[1], nil
+			return HashKey{Name: HashKeyMetadata, MetadataField: tokens[1]}, nil
 		}
-		return HashKeyMetadata, DefaultMetadataKeyField, nil
+		return HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}, nil
 	case string(HashKeySource):
-		return HashKeySource, "", nil
+		return HashKey{Name: HashKeySource}, nil
 	default:
-		return "", "", ErrInvalidHashKeyType
+		return HashKey{}, ErrInvalidHashKeyType
 	}
 }
 
@@ -66,23 +72,23 @@ func ParseHashKeyType(s string) (HashKeyType, string, error) {
 // Returns the hash key string or an error if the hash key is required but empty.
 // Defaults to metadata with the default field if keyType is empty.
 // Returns ErrEmptyHashKey if the extracted hash key value is empty or missing.
-func GetHashKey(msg *wrp.Message, keyType HashKeyType, metadataKey string) (string, error) {
-	if keyType == "" {
-		keyType = HashKeyMetadata
-		metadataKey = DefaultMetadataKeyField
+func (h HashKey) GetHashKey(msg *wrp.Message) (string, error) {
+	if h.Name == "" {
+		h.Name = HashKeyMetadata
+		h.MetadataField = DefaultMetadataKeyField
 	}
 
-	switch keyType {
+	switch h.Name {
 	case HashKeyNone:
 		return "", nil
 	case HashKeyMetadata:
-		if metadataKey == "" {
+		if h.MetadataField == "" {
 			return "", fmt.Errorf("metadata key field cannot be empty: %w", ErrEmptyHashKey)
 		}
 		if msg.Metadata == nil {
 			return "", ErrEmptyHashKey
 		}
-		hashKey := msg.Metadata[metadataKey]
+		hashKey := msg.Metadata[h.MetadataField]
 		if hashKey == "" {
 			return "", ErrEmptyHashKey
 		}
@@ -98,6 +104,6 @@ func GetHashKey(msg *wrp.Message, keyType HashKeyType, metadataKey string) (stri
 		return deviceID.ID(), nil
 
 	default:
-		return "", fmt.Errorf("unsupported hash key type: %v: %w", keyType, ErrInvalidHashKeyType)
+		return "", fmt.Errorf("unsupported hash key type: %v: %w", h.Name, ErrInvalidHashKeyType)
 	}
 }

--- a/hash_key_provider.go
+++ b/hash_key_provider.go
@@ -11,45 +11,49 @@ import (
 	"github.com/xmidt-org/wrp-go/v5"
 )
 
+var (
+	ErrInvalidHashKeyType      = errors.New("invalid hash key type")
+	ErrEmptyMetatadataKeyField = errors.New("metadata key field is empty")
+)
+
 const (
-	// MetadataKeyDeviceID is the metadata key for hardware device ID.
-	MetadataKeyDeviceID = "hw-deviceid"
+	DefaultMetadataKeyField = "hw-deviceid"
 )
 
 // HashKeyType represents the type of hash key to extract from a WRP message.
-type HashKeyType int
+type HashKeyType string
 
 const (
-	// HashKeyDeviceID is the default key.
-	HashKeyDeviceID HashKeyType = iota
+	// key from any field in metadata
+	HashKeyMetadata HashKeyType = "metadata"
 
-	// HashKeyNone indicates no hash key should be used (e.g., for non-sharded topics).
-	HashKeyNone
+	// deviceId parsed from the source field
+	HashKeySource HashKeyType = "source"
+
+	// indicates no hash key should be used (e.g., for non-sharded topics).
+	HashKeyNone HashKeyType = "none"
 )
-
-// String returns the string representation of the HashKeyType.
-func (h HashKeyType) String() (string, error) {
-	switch h {
-	case HashKeyNone:
-		return "none", nil
-	case HashKeyDeviceID:
-		return "deviceid", nil
-	default:
-		return fmt.Sprintf("unknown(%d)", h), fmt.Errorf("unknown hash key type: %d", h)
-	}
-}
 
 // ParseHashKeyType converts a string to a HashKeyType.
 // The comparison is case-insensitive.
-// Defaults to deviceId
-func ParseHashKeyType(s string) HashKeyType {
-	switch strings.ToLower(s) {
-	case "none":
-		return HashKeyNone
-	case "deviceid":
-		return HashKeyDeviceID
+// Defaults to metadata/hw-deviceid
+func ParseHashKeyType(s string) (HashKeyType, string, error) {
+	if s == "" {
+		return HashKeyMetadata, DefaultMetadataKeyField, nil
+	}
+	tokens := strings.Split(s, "/")
+	switch strings.ToLower(tokens[0]) {
+	case string(HashKeyNone):
+		return HashKeyNone, "", nil
+	case string(HashKeyMetadata):
+		if (len(tokens) >= 2) && tokens[1] != "" {
+			return HashKeyMetadata, tokens[1], nil
+		}
+		return HashKeyMetadata, DefaultMetadataKeyField, nil
+	case string(HashKeySource):
+		return HashKeySource, "", nil
 	default:
-		return HashKeyDeviceID
+		return HashKeyMetadata, DefaultMetadataKeyField, ErrInvalidHashKeyType
 	}
 }
 
@@ -59,27 +63,37 @@ var (
 )
 
 // GetHashKey extracts the hash key from a WRP message based on the specified hash key type.
-// Returns the hash key string or an error if the hash key is required but empty.
-//
-// Behavior by hash key type:
-//   - HashKeyNone: Returns empty string and nil error.
-//   - HashKeyDeviceID: Returns the value from msg.Metadata["hw-deviceid"] or ErrEmptyHashKey if empty.
-func GetHashKey(msg *wrp.Message, keyType HashKeyType) (string, error) {
+// Returns the hash key string or an error if the hash key is required but empty.  Defaults
+// to metadata with the default field if keyType is empty.
+func GetHashKey(msg *wrp.Message, keyType HashKeyType, metadataKey string) (string, error) {
+	if keyType == "" {
+		keyType = HashKeyMetadata
+		metadataKey = DefaultMetadataKeyField
+	}
+
 	switch keyType {
 	case HashKeyNone:
 		return "", nil
-
-	case HashKeyDeviceID:
+	case HashKeyMetadata:
 		if msg.Metadata == nil {
 			return "", ErrEmptyHashKey
 		}
-		hashKey := msg.Metadata[MetadataKeyDeviceID]
+		hashKey := msg.Metadata[metadataKey]
 		if hashKey == "" {
 			return "", ErrEmptyHashKey
 		}
 		return hashKey, nil
+	case HashKeySource:
+		if msg.Source == "" {
+			return "", ErrEmptyHashKey
+		}
+		deviceID, err := wrp.ParseDeviceID(msg.Source)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse device ID from source: %w", err)
+		}
+		return deviceID.ID(), nil
 
 	default:
-		return "", fmt.Errorf("unsupported hash key type: %v", keyType)
+		return "", fmt.Errorf("unsupported hash key type: %v: %w", keyType, ErrInvalidHashKeyType)
 	}
 }

--- a/hash_key_provider.go
+++ b/hash_key_provider.go
@@ -12,11 +12,15 @@ import (
 )
 
 var (
-	ErrInvalidHashKeyType      = errors.New("invalid hash key type")
-	ErrEmptyMetatadataKeyField = errors.New("metadata key field is empty")
+	// ErrInvalidHashKeyType is returned when an unsupported hash key type is specified.
+	ErrInvalidHashKeyType = errors.New("invalid hash key type")
+
+	// ErrEmptyHashKey is returned when the hash key is empty but required.
+	ErrEmptyHashKey = errors.New("hash key is empty")
 )
 
 const (
+	// DefaultMetadataKeyField is the default metadata field used for hash key extraction.
 	DefaultMetadataKeyField = "hw-deviceid"
 )
 
@@ -36,7 +40,8 @@ const (
 
 // ParseHashKeyType converts a string to a HashKeyType.
 // The comparison is case-insensitive.
-// Defaults to metadata/hw-deviceid
+// Defaults to metadata/hw-deviceid when the input string is empty.
+// Returns an error if the hash key type is not recognized.
 func ParseHashKeyType(s string) (HashKeyType, string, error) {
 	if s == "" {
 		return HashKeyMetadata, DefaultMetadataKeyField, nil
@@ -53,18 +58,14 @@ func ParseHashKeyType(s string) (HashKeyType, string, error) {
 	case string(HashKeySource):
 		return HashKeySource, "", nil
 	default:
-		return HashKeyMetadata, DefaultMetadataKeyField, ErrInvalidHashKeyType
+		return "", "", ErrInvalidHashKeyType
 	}
 }
 
-var (
-	// ErrEmptyHashKey is returned when the hash key is empty but required.
-	ErrEmptyHashKey = errors.New("hash key is empty")
-)
-
 // GetHashKey extracts the hash key from a WRP message based on the specified hash key type.
-// Returns the hash key string or an error if the hash key is required but empty.  Defaults
-// to metadata with the default field if keyType is empty.
+// Returns the hash key string or an error if the hash key is required but empty.
+// Defaults to metadata with the default field if keyType is empty.
+// Returns ErrEmptyHashKey if the extracted hash key value is empty or missing.
 func GetHashKey(msg *wrp.Message, keyType HashKeyType, metadataKey string) (string, error) {
 	if keyType == "" {
 		keyType = HashKeyMetadata
@@ -75,6 +76,9 @@ func GetHashKey(msg *wrp.Message, keyType HashKeyType, metadataKey string) (stri
 	case HashKeyNone:
 		return "", nil
 	case HashKeyMetadata:
+		if metadataKey == "" {
+			return "", fmt.Errorf("metadata key field cannot be empty: %w", ErrEmptyHashKey)
+		}
 		if msg.Metadata == nil {
 			return "", ErrEmptyHashKey
 		}

--- a/hash_key_provider.go
+++ b/hash_key_provider.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package wrpkafka
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/xmidt-org/wrp-go/v5"
+)
+
+const (
+	// MetadataKeyDeviceID is the metadata key for hardware device ID.
+	MetadataKeyDeviceID = "hw-deviceid"
+)
+
+// HashKeyType represents the type of hash key to extract from a WRP message.
+type HashKeyType int
+
+const (
+	// HashKeyDeviceID is the default key.
+	HashKeyDeviceID HashKeyType = iota
+
+	// HashKeyNone indicates no hash key should be used (e.g., for non-sharded topics).
+	HashKeyNone
+)
+
+// String returns the string representation of the HashKeyType.
+func (h HashKeyType) String() (string, error) {
+	switch h {
+	case HashKeyNone:
+		return "none", nil
+	case HashKeyDeviceID:
+		return "deviceid", nil
+	default:
+		return fmt.Sprintf("unknown(%d)", h), fmt.Errorf("unknown hash key type: %d", h)
+	}
+}
+
+// ParseHashKeyType converts a string to a HashKeyType.
+// The comparison is case-insensitive.
+// Defaults to deviceId
+func ParseHashKeyType(s string) HashKeyType {
+	switch strings.ToLower(s) {
+	case "none":
+		return HashKeyNone
+	case "deviceid":
+		return HashKeyDeviceID
+	default:
+		return HashKeyDeviceID
+	}
+}
+
+var (
+	// ErrEmptyHashKey is returned when the hash key is empty but required.
+	ErrEmptyHashKey = errors.New("hash key is empty")
+)
+
+// GetHashKey extracts the hash key from a WRP message based on the specified hash key type.
+// Returns the hash key string or an error if the hash key is required but empty.
+//
+// Behavior by hash key type:
+//   - HashKeyNone: Returns empty string and nil error.
+//   - HashKeyDeviceID: Returns the value from msg.Metadata["hw-deviceid"] or ErrEmptyHashKey if empty.
+func GetHashKey(msg *wrp.Message, keyType HashKeyType) (string, error) {
+	switch keyType {
+	case HashKeyNone:
+		return "", nil
+
+	case HashKeyDeviceID:
+		if msg.Metadata == nil {
+			return "", ErrEmptyHashKey
+		}
+		hashKey := msg.Metadata[MetadataKeyDeviceID]
+		if hashKey == "" {
+			return "", ErrEmptyHashKey
+		}
+		return hashKey, nil
+
+	default:
+		return "", fmt.Errorf("unsupported hash key type: %v", keyType)
+	}
+}

--- a/hash_key_provider_test.go
+++ b/hash_key_provider_test.go
@@ -83,8 +83,8 @@ func (s *HashKeyProviderSuite) TestParseHashKeyType_Invalid() {
 	keyType, field, err := ParseHashKeyType("invalid")
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+	assert.Equal(s.T(), HashKeyType(""), keyType)
+	assert.Equal(s.T(), "", field)
 }
 
 func (s *HashKeyProviderSuite) TestGetHashKey_None() {

--- a/hash_key_provider_test.go
+++ b/hash_key_provider_test.go
@@ -16,82 +16,84 @@ type HashKeyProviderSuite struct {
 	suite.Suite
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Empty() {
-	keyType, field, err := ParseHashKeyType("")
+// ParseHashKey tests
+func (s *HashKeyProviderSuite) TestParseHashKey_Empty() {
+	hashKey, err := ParseHashKey("")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+	assert.Equal(s.T(), HashKeyMetadata, hashKey.Name)
+	assert.Equal(s.T(), DefaultMetadataKeyField, hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_None() {
-	keyType, field, err := ParseHashKeyType("none")
+func (s *HashKeyProviderSuite) TestParseHashKey_None() {
+	hashKey, err := ParseHashKey("none")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyNone, keyType)
-	assert.Equal(s.T(), "", field)
+	assert.Equal(s.T(), HashKeyNone, hashKey.Name)
+	assert.Equal(s.T(), "", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_None_CaseInsensitive() {
-	keyType, field, err := ParseHashKeyType("NONE")
+func (s *HashKeyProviderSuite) TestParseHashKey_None_CaseInsensitive() {
+	hashKey, err := ParseHashKey("NONE")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyNone, keyType)
-	assert.Equal(s.T(), "", field)
+	assert.Equal(s.T(), HashKeyNone, hashKey.Name)
+	assert.Equal(s.T(), "", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_Default() {
-	keyType, field, err := ParseHashKeyType("metadata")
+func (s *HashKeyProviderSuite) TestParseHashKey_Metadata_Default() {
+	hashKey, err := ParseHashKey("metadata")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+	assert.Equal(s.T(), HashKeyMetadata, hashKey.Name)
+	assert.Equal(s.T(), DefaultMetadataKeyField, hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_CustomField() {
-	keyType, field, err := ParseHashKeyType("metadata/custom-field")
+func (s *HashKeyProviderSuite) TestParseHashKey_Metadata_CustomField() {
+	hashKey, err := ParseHashKey("metadata/custom-field")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), "custom-field", field)
+	assert.Equal(s.T(), HashKeyMetadata, hashKey.Name)
+	assert.Equal(s.T(), "custom-field", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_EmptyField() {
-	keyType, field, err := ParseHashKeyType("metadata/")
+func (s *HashKeyProviderSuite) TestParseHashKey_Metadata_EmptyField() {
+	hashKey, err := ParseHashKey("metadata/")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+	assert.Equal(s.T(), HashKeyMetadata, hashKey.Name)
+	assert.Equal(s.T(), DefaultMetadataKeyField, hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_CaseInsensitive() {
-	keyType, field, err := ParseHashKeyType("METADATA/my-field")
+func (s *HashKeyProviderSuite) TestParseHashKey_Metadata_CaseInsensitive() {
+	hashKey, err := ParseHashKey("METADATA/my-field")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeyMetadata, keyType)
-	assert.Equal(s.T(), "my-field", field)
+	assert.Equal(s.T(), HashKeyMetadata, hashKey.Name)
+	assert.Equal(s.T(), "my-field", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Source() {
-	keyType, field, err := ParseHashKeyType("source")
+func (s *HashKeyProviderSuite) TestParseHashKey_Source() {
+	hashKey, err := ParseHashKey("source")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeySource, keyType)
-	assert.Equal(s.T(), "", field)
+	assert.Equal(s.T(), HashKeySource, hashKey.Name)
+	assert.Equal(s.T(), "", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Source_CaseInsensitive() {
-	keyType, field, err := ParseHashKeyType("SOURCE")
+func (s *HashKeyProviderSuite) TestParseHashKey_Source_CaseInsensitive() {
+	hashKey, err := ParseHashKey("SOURCE")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), HashKeySource, keyType)
-	assert.Equal(s.T(), "", field)
+	assert.Equal(s.T(), HashKeySource, hashKey.Name)
+	assert.Equal(s.T(), "", hashKey.MetadataField)
 }
 
-func (s *HashKeyProviderSuite) TestParseHashKeyType_Invalid() {
-	keyType, field, err := ParseHashKeyType("invalid")
+func (s *HashKeyProviderSuite) TestParseHashKey_Invalid() {
+	hashKey, err := ParseHashKey("invalid")
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
-	assert.Equal(s.T(), HashKeyType(""), keyType)
-	assert.Equal(s.T(), "", field)
+	assert.Equal(s.T(), HashKey{}, hashKey)
 }
 
+// GetHashKey tests
 func (s *HashKeyProviderSuite) TestGetHashKey_None() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
 	}
-	key, err := GetHashKey(msg, HashKeyNone, "")
+	hashKey := HashKey{Name: HashKeyNone}
+	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "", key)
 }
@@ -100,7 +102,8 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Valid() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
 	}
-	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "mac:112233445566", key)
 }
@@ -109,16 +112,28 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_CustomField() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"custom-id": "some-value"},
 	}
-	key, err := GetHashKey(msg, HashKeyMetadata, "custom-id")
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "custom-id"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "some-value", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_DefaultWhenEmpty() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+	}
+	hashKey := HashKey{} // Empty struct should default to metadata/hw-deviceid
+	key, err := hashKey.GetHashKey(msg)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "mac:112233445566", key)
 }
 
 func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_NilMetadata() {
 	msg := &wrp.Message{
 		Metadata: nil,
 	}
-	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
 	assert.Equal(s.T(), "", key)
@@ -128,7 +143,8 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_EmptyValue() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"hw-deviceid": ""},
 	}
-	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
 	assert.Equal(s.T(), "", key)
@@ -138,9 +154,21 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_MissingField() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"other-field": "value"},
 	}
-	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_EmptyFieldName() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+	}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: ""}
+	key, err := hashKey.GetHashKey(msg)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "metadata key field cannot be empty")
 	assert.Equal(s.T(), "", key)
 }
 
@@ -148,7 +176,8 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Source_Valid() {
 	msg := &wrp.Message{
 		Source: "mac:112233445566/service",
 	}
-	key, err := GetHashKey(msg, HashKeySource, "")
+	hashKey := HashKey{Name: HashKeySource}
+	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "112233445566", key)
 }
@@ -157,7 +186,8 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Source_EmptySource() {
 	msg := &wrp.Message{
 		Source: "",
 	}
-	key, err := GetHashKey(msg, HashKeySource, "")
+	hashKey := HashKey{Name: HashKeySource}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
 	assert.Equal(s.T(), "", key)
@@ -167,8 +197,10 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Source_InvalidFormat() {
 	msg := &wrp.Message{
 		Source: "invalid-format",
 	}
-	key, err := GetHashKey(msg, HashKeySource, "")
+	hashKey := HashKey{Name: HashKeySource}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "failed to parse device ID from source")
 	assert.Equal(s.T(), "", key)
 }
 
@@ -176,10 +208,60 @@ func (s *HashKeyProviderSuite) TestGetHashKey_InvalidKeyType() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
 	}
-	key, err := GetHashKey(msg, HashKeyType("invalid"), "hw-deviceid")
+	hashKey := HashKey{Name: HashKeyType("invalid"), MetadataField: "hw-deviceid"}
+	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
 	assert.Equal(s.T(), "", key)
+}
+
+// Integration tests - combining ParseHashKey and GetHashKey
+func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_Metadata() {
+	hashKey, err := ParseHashKey("metadata/hw-deviceid")
+	assert.NoError(s.T(), err)
+
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+	}
+	key, err := hashKey.GetHashKey(msg)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "mac:112233445566", key)
+}
+
+func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_Source() {
+	hashKey, err := ParseHashKey("source")
+	assert.NoError(s.T(), err)
+
+	msg := &wrp.Message{
+		Source: "mac:112233445566/service",
+	}
+	key, err := hashKey.GetHashKey(msg)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "112233445566", key)
+}
+
+func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_None() {
+	hashKey, err := ParseHashKey("none")
+	assert.NoError(s.T(), err)
+
+	msg := &wrp.Message{
+		Source: "mac:112233445566/service",
+	}
+	key, err := hashKey.GetHashKey(msg)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_Default() {
+	hashKey, err := ParseHashKey("")
+	assert.NoError(s.T(), err)
+
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+	}
+	key, err := hashKey.GetHashKey(msg)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "mac:112233445566", key)
 }
 
 func TestHashKeyProviderSuite(t *testing.T) {

--- a/hash_key_provider_test.go
+++ b/hash_key_provider_test.go
@@ -4,276 +4,184 @@
 package wrpkafka
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/xmidt-org/wrp-go/v5"
 )
 
-func TestParseHashKeyType(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input string
-		want  HashKeyType
-	}{
-		{
-			name:  "parse none",
-			input: "none",
-			want:  HashKeyNone,
-		},
-		{
-			name:  "parse deviceid",
-			input: "deviceid",
-			want:  HashKeyDeviceID,
-		},
-		{
-			name:  "invalid type",
-			input: "invalid",
-			want:  HashKeyDeviceID,
-		},
-		{
-			name:  "empty string",
-			input: "",
-			want:  HashKeyDeviceID,
-		},
-		{
-			name:  "case insensitive - uppercase",
-			input: "DEVICEID",
-			want:  HashKeyDeviceID,
-		},
-		{
-			name:  "case insensitive - mixed case",
-			input: "DeviceId",
-			want:  HashKeyDeviceID,
-		},
-		{
-			name:  "case insensitive - uppercase none",
-			input: "NONE",
-			want:  HashKeyNone,
-		},
-		{
-			name:  "case insensitive - mixed case none",
-			input: "None",
-			want:  HashKeyNone,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := ParseHashKeyType(tt.input)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+type HashKeyProviderSuite struct {
+	suite.Suite
 }
 
-func TestHashKeyType_String(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		keyType   HashKeyType
-		wantStr   string
-		wantError bool
-	}{
-		{
-			name:      "HashKeyNone",
-			keyType:   HashKeyNone,
-			wantStr:   "none",
-			wantError: false,
-		},
-		{
-			name:      "HashKeyDeviceID",
-			keyType:   HashKeyDeviceID,
-			wantStr:   "deviceid",
-			wantError: false,
-		},
-		{
-			name:      "unknown type",
-			keyType:   HashKeyType(999),
-			wantStr:   "unknown(999)",
-			wantError: true,
-		},
-		{
-			name:      "negative value",
-			keyType:   HashKeyType(-1),
-			wantStr:   "unknown(-1)",
-			wantError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := tt.keyType.String()
-			assert.Equal(t, tt.wantStr, got)
-			if tt.wantError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "unknown hash key type")
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Empty() {
+	keyType, field, err := ParseHashKeyType("")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), DefaultMetadataKeyField, field)
 }
 
-func TestGetHashKey(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		msg       *wrp.Message
-		keyType   HashKeyType
-		want      string
-		wantError error
-	}{
-		{
-			name:      "HashKeyNone returns empty string",
-			msg:       &wrp.Message{},
-			keyType:   HashKeyNone,
-			want:      "",
-			wantError: nil,
-		},
-		{
-			name: "HashKeyNone with message data still returns empty",
-			msg: &wrp.Message{
-				Metadata: map[string]string{
-					MetadataKeyDeviceID: "device123",
-				},
-			},
-			keyType:   HashKeyNone,
-			want:      "",
-			wantError: nil,
-		},
-		{
-			name: "HashKeyDeviceID with valid device ID",
-			msg: &wrp.Message{
-				Metadata: map[string]string{
-					MetadataKeyDeviceID: "mac:112233445566",
-				},
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "mac:112233445566",
-			wantError: nil,
-		},
-		{
-			name: "HashKeyDeviceID with empty device ID",
-			msg: &wrp.Message{
-				Metadata: map[string]string{
-					MetadataKeyDeviceID: "",
-				},
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "",
-			wantError: ErrEmptyHashKey,
-		},
-		{
-			name: "HashKeyDeviceID with nil metadata",
-			msg: &wrp.Message{
-				Metadata: nil,
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "",
-			wantError: ErrEmptyHashKey,
-		},
-		{
-			name: "HashKeyDeviceID with empty metadata map",
-			msg: &wrp.Message{
-				Metadata: map[string]string{},
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "",
-			wantError: ErrEmptyHashKey,
-		},
-		{
-			name: "HashKeyDeviceID with other metadata but no device ID",
-			msg: &wrp.Message{
-				Metadata: map[string]string{
-					"other-key": "other-value",
-				},
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "",
-			wantError: ErrEmptyHashKey,
-		},
-		{
-			name: "HashKeyDeviceID with complex device ID",
-			msg: &wrp.Message{
-				Metadata: map[string]string{
-					MetadataKeyDeviceID: "uuid:12345-67890-abcdef",
-				},
-			},
-			keyType:   HashKeyDeviceID,
-			want:      "uuid:12345-67890-abcdef",
-			wantError: nil,
-		},
-		{
-			name:      "unsupported hash key type",
-			msg:       &wrp.Message{},
-			keyType:   HashKeyType(999),
-			want:      "",
-			wantError: nil, // We check for error containing specific text
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := GetHashKey(tt.msg, tt.keyType)
-			assert.Equal(t, tt.want, got)
-
-			if tt.wantError != nil {
-				require.Error(t, err)
-				assert.ErrorIs(t, err, tt.wantError)
-			} else if tt.name == "unsupported hash key type" {
-				// Special case: check for unsupported type error
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unsupported hash key type")
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+func (s *HashKeyProviderSuite) TestParseHashKeyType_None() {
+	keyType, field, err := ParseHashKeyType("none")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyNone, keyType)
+	assert.Equal(s.T(), "", field)
 }
 
-func TestGetHashKey_MetadataKeyConstant(t *testing.T) {
-	t.Parallel()
-
-	// Verify that the constant is correctly defined
-	assert.Equal(t, "hw-deviceid", MetadataKeyDeviceID, "MetadataKeyDeviceID constant should match expected value")
+func (s *HashKeyProviderSuite) TestParseHashKeyType_None_CaseInsensitive() {
+	keyType, field, err := ParseHashKeyType("NONE")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyNone, keyType)
+	assert.Equal(s.T(), "", field)
 }
 
-func TestHashKeyType_RoundTrip(t *testing.T) {
-	t.Parallel()
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_Default() {
+	keyType, field, err := ParseHashKeyType("metadata")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+}
 
-	// Test that parsing and converting back to string works correctly
-	tests := []struct {
-		name    string
-		keyType HashKeyType
-	}{
-		{"none", HashKeyNone},
-		{"deviceid", HashKeyDeviceID},
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_CustomField() {
+	keyType, field, err := ParseHashKeyType("metadata/custom-field")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), "custom-field", field)
+}
+
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_EmptyField() {
+	keyType, field, err := ParseHashKeyType("metadata/")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+}
+
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Metadata_CaseInsensitive() {
+	keyType, field, err := ParseHashKeyType("METADATA/my-field")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), "my-field", field)
+}
+
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Source() {
+	keyType, field, err := ParseHashKeyType("source")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeySource, keyType)
+	assert.Equal(s.T(), "", field)
+}
+
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Source_CaseInsensitive() {
+	keyType, field, err := ParseHashKeyType("SOURCE")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), HashKeySource, keyType)
+	assert.Equal(s.T(), "", field)
+}
+
+func (s *HashKeyProviderSuite) TestParseHashKeyType_Invalid() {
+	keyType, field, err := ParseHashKeyType("invalid")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
+	assert.Equal(s.T(), HashKeyMetadata, keyType)
+	assert.Equal(s.T(), DefaultMetadataKeyField, field)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_None() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
 	}
+	key, err := GetHashKey(msg, HashKeyNone, "")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "", key)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			// Convert to string
-			str, err := tt.keyType.String()
-			require.NoError(t, err)
-
-			// Parse back
-			parsed := ParseHashKeyType(str)
-
-			// Should match original
-			assert.Equal(t, tt.keyType, parsed)
-		})
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Valid() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
 	}
+	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "mac:112233445566", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_CustomField() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"custom-id": "some-value"},
+	}
+	key, err := GetHashKey(msg, HashKeyMetadata, "custom-id")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "some-value", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_NilMetadata() {
+	msg := &wrp.Message{
+		Metadata: nil,
+	}
+	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_EmptyValue() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": ""},
+	}
+	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_MissingField() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"other-field": "value"},
+	}
+	key, err := GetHashKey(msg, HashKeyMetadata, "hw-deviceid")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Source_Valid() {
+	msg := &wrp.Message{
+		Source: "mac:112233445566/service",
+	}
+	key, err := GetHashKey(msg, HashKeySource, "")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), "112233445566", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Source_EmptySource() {
+	msg := &wrp.Message{
+		Source: "",
+	}
+	key, err := GetHashKey(msg, HashKeySource, "")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_Source_InvalidFormat() {
+	msg := &wrp.Message{
+		Source: "invalid-format",
+	}
+	key, err := GetHashKey(msg, HashKeySource, "")
+	assert.Error(s.T(), err)
+	assert.Equal(s.T(), "", key)
+}
+
+func (s *HashKeyProviderSuite) TestGetHashKey_InvalidKeyType() {
+	msg := &wrp.Message{
+		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+	}
+	key, err := GetHashKey(msg, HashKeyType("invalid"), "hw-deviceid")
+	assert.Error(s.T(), err)
+	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
+	assert.Equal(s.T(), "", key)
+}
+
+func TestHashKeyProviderSuite(t *testing.T) {
+	suite.Run(t, new(HashKeyProviderSuite))
 }

--- a/hash_key_provider_test.go
+++ b/hash_key_provider_test.go
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package wrpkafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xmidt-org/wrp-go/v5"
+)
+
+func TestParseHashKeyType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  HashKeyType
+	}{
+		{
+			name:  "parse none",
+			input: "none",
+			want:  HashKeyNone,
+		},
+		{
+			name:  "parse deviceid",
+			input: "deviceid",
+			want:  HashKeyDeviceID,
+		},
+		{
+			name:  "invalid type",
+			input: "invalid",
+			want:  HashKeyDeviceID,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  HashKeyDeviceID,
+		},
+		{
+			name:  "case insensitive - uppercase",
+			input: "DEVICEID",
+			want:  HashKeyDeviceID,
+		},
+		{
+			name:  "case insensitive - mixed case",
+			input: "DeviceId",
+			want:  HashKeyDeviceID,
+		},
+		{
+			name:  "case insensitive - uppercase none",
+			input: "NONE",
+			want:  HashKeyNone,
+		},
+		{
+			name:  "case insensitive - mixed case none",
+			input: "None",
+			want:  HashKeyNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseHashKeyType(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHashKeyType_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		keyType   HashKeyType
+		wantStr   string
+		wantError bool
+	}{
+		{
+			name:      "HashKeyNone",
+			keyType:   HashKeyNone,
+			wantStr:   "none",
+			wantError: false,
+		},
+		{
+			name:      "HashKeyDeviceID",
+			keyType:   HashKeyDeviceID,
+			wantStr:   "deviceid",
+			wantError: false,
+		},
+		{
+			name:      "unknown type",
+			keyType:   HashKeyType(999),
+			wantStr:   "unknown(999)",
+			wantError: true,
+		},
+		{
+			name:      "negative value",
+			keyType:   HashKeyType(-1),
+			wantStr:   "unknown(-1)",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tt.keyType.String()
+			assert.Equal(t, tt.wantStr, got)
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown hash key type")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetHashKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		msg       *wrp.Message
+		keyType   HashKeyType
+		want      string
+		wantError error
+	}{
+		{
+			name:      "HashKeyNone returns empty string",
+			msg:       &wrp.Message{},
+			keyType:   HashKeyNone,
+			want:      "",
+			wantError: nil,
+		},
+		{
+			name: "HashKeyNone with message data still returns empty",
+			msg: &wrp.Message{
+				Metadata: map[string]string{
+					MetadataKeyDeviceID: "device123",
+				},
+			},
+			keyType:   HashKeyNone,
+			want:      "",
+			wantError: nil,
+		},
+		{
+			name: "HashKeyDeviceID with valid device ID",
+			msg: &wrp.Message{
+				Metadata: map[string]string{
+					MetadataKeyDeviceID: "mac:112233445566",
+				},
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "mac:112233445566",
+			wantError: nil,
+		},
+		{
+			name: "HashKeyDeviceID with empty device ID",
+			msg: &wrp.Message{
+				Metadata: map[string]string{
+					MetadataKeyDeviceID: "",
+				},
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "",
+			wantError: ErrEmptyHashKey,
+		},
+		{
+			name: "HashKeyDeviceID with nil metadata",
+			msg: &wrp.Message{
+				Metadata: nil,
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "",
+			wantError: ErrEmptyHashKey,
+		},
+		{
+			name: "HashKeyDeviceID with empty metadata map",
+			msg: &wrp.Message{
+				Metadata: map[string]string{},
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "",
+			wantError: ErrEmptyHashKey,
+		},
+		{
+			name: "HashKeyDeviceID with other metadata but no device ID",
+			msg: &wrp.Message{
+				Metadata: map[string]string{
+					"other-key": "other-value",
+				},
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "",
+			wantError: ErrEmptyHashKey,
+		},
+		{
+			name: "HashKeyDeviceID with complex device ID",
+			msg: &wrp.Message{
+				Metadata: map[string]string{
+					MetadataKeyDeviceID: "uuid:12345-67890-abcdef",
+				},
+			},
+			keyType:   HashKeyDeviceID,
+			want:      "uuid:12345-67890-abcdef",
+			wantError: nil,
+		},
+		{
+			name:      "unsupported hash key type",
+			msg:       &wrp.Message{},
+			keyType:   HashKeyType(999),
+			want:      "",
+			wantError: nil, // We check for error containing specific text
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetHashKey(tt.msg, tt.keyType)
+			assert.Equal(t, tt.want, got)
+
+			if tt.wantError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantError)
+			} else if tt.name == "unsupported hash key type" {
+				// Special case: check for unsupported type error
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported hash key type")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetHashKey_MetadataKeyConstant(t *testing.T) {
+	t.Parallel()
+
+	// Verify that the constant is correctly defined
+	assert.Equal(t, "hw-deviceid", MetadataKeyDeviceID, "MetadataKeyDeviceID constant should match expected value")
+}
+
+func TestHashKeyType_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Test that parsing and converting back to string works correctly
+	tests := []struct {
+		name    string
+		keyType HashKeyType
+	}{
+		{"none", HashKeyNone},
+		{"deviceid", HashKeyDeviceID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Convert to string
+			str, err := tt.keyType.String()
+			require.NoError(t, err)
+
+			// Parse back
+			parsed := ParseHashKeyType(str)
+
+			// Should match original
+			assert.Equal(t, tt.keyType, parsed)
+		})
+	}
+}

--- a/integration_helpers_test.go
+++ b/integration_helpers_test.go
@@ -202,6 +202,7 @@ func createTestMessage(eventType string, deviceID string, qos int64) *wrp.Messag
 	return &wrp.Message{
 		Type:             wrp.SimpleEventMessageType,
 		Source:           deviceID,
+		Metadata:         map[string]string{"hw-deviceid": deviceID},
 		Destination:      "event:" + eventType + "/" + deviceID,
 		Payload:          []byte(`{"status":"online"}`),
 		QualityOfService: wrp.QOSValue(qos),

--- a/publisher.go
+++ b/publisher.go
@@ -408,7 +408,7 @@ func (p *Publisher) buildRecords(msg *wrp.Message) ([]*kgo.Record, []TopicShardS
 	// Create records for each topic
 	records := make([]*kgo.Record, 0, len(topics))
 	for _, topic := range topics {
-		partitionKey, err := GetHashKey(msg, topic.Key)
+		partitionKey, err := GetHashKey(msg, topic.KeyType, topic.MetadataKey)
 		if err != nil {
 			return nil, nil,
 				errors.Join(

--- a/publisher.go
+++ b/publisher.go
@@ -408,7 +408,7 @@ func (p *Publisher) buildRecords(msg *wrp.Message) ([]*kgo.Record, []TopicShardS
 	// Create records for each topic
 	records := make([]*kgo.Record, 0, len(topics))
 	for _, topic := range topics {
-		partitionKey, err := GetHashKey(msg, topic.KeyType, topic.MetadataKey)
+		partitionKey, err := topic.HashKey.GetHashKey(msg)
 		if err != nil {
 			return nil, nil,
 				errors.Join(

--- a/publisher.go
+++ b/publisher.go
@@ -405,23 +405,21 @@ func (p *Publisher) buildRecords(msg *wrp.Message) ([]*kgo.Record, []TopicShardS
 			)
 	}
 
-	// Use device ID (from WRP Source) as partition key for ordering
-	deviceID, err := wrp.ParseDeviceID(msg.Source)
-	if err != nil {
-		return nil, nil,
-			errors.Join(
-				ErrValidation,
-				fmt.Errorf("invalid device ID in WRP Source `%s`", msg.Source),
-				err,
-			)
-	}
-
 	// Create records for each topic
 	records := make([]*kgo.Record, 0, len(topics))
 	for _, topic := range topics {
+		partitionKey, err := GetHashKey(msg, topic.Key)
+		if err != nil {
+			return nil, nil,
+				errors.Join(
+					ErrValidation,
+					fmt.Errorf("invalid hash key in WRP message `%v`", msg.Metadata),
+					err,
+				)
+		}
 		record := &kgo.Record{
-			Topic:   topic,
-			Key:     deviceID.Bytes(),
+			Topic:   topic.Name,
+			Key:     []byte(partitionKey),
 			Value:   encoded,
 			Headers: dynCfg.headers(msg),
 		}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -103,7 +103,7 @@ func TestProduceQoS(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Source:           "mac:112233445566",
+			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10, // low QoS
 		}
@@ -125,7 +125,7 @@ func TestProduceQoS(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Source:           "mac:112233445566",
+			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 50, // medium QoS
 		}
@@ -161,7 +161,7 @@ func TestProduceQoS(t *testing.T) {
 
 				msg := &wrp.Message{
 					Type:             wrp.SimpleEventMessageType,
-					Source:           "mac:112233445566",
+					Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 					Destination:      "event:test",
 					QualityOfService: wrp.QOSValue(tt.qos),
 				}
@@ -212,14 +212,17 @@ func TestProduceErrors(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
 
-		msg := &wrp.Message{Destination: "event:test"}
+		msg := &wrp.Message{
+			Destination: "event:test",
+			Metadata:    map[string]string{"hw-deviceid": "mac:112233445566"},
+		}
 
 		outcome, err := p.Produce(ctx, msg)
 		assert.Error(t, err)
 		assert.Equal(t, Failed, outcome)
 	})
 
-	t.Run("no records", func(t *testing.T) {
+	t.Run("missing hash key", func(t *testing.T) {
 		t.Parallel()
 		p := newTestPublisher(DynamicConfig{TopicMap: []TopicRoute{{Pattern: "*", Topic: "t"}}})
 		p.clientMu.Lock()
@@ -229,10 +232,15 @@ func TestProduceErrors(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		msg := &wrp.Message{Destination: "event:test"}
+		msg := &wrp.Message{
+			Destination: "event:test",
+			// No metadata - will cause ErrEmptyHashKey since HashKeyDeviceID is the default
+		}
 
 		outcome, err := p.Produce(ctx, msg)
 		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrValidation)
+		assert.Contains(t, err.Error(), "hash key is empty")
 		assert.Equal(t, Failed, outcome)
 	})
 }
@@ -296,7 +304,7 @@ func TestEventListeners(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Source:           "mac:112233445566",
+			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10,
 		}
@@ -345,7 +353,7 @@ func TestEventListeners(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Source:           "mac:112233445566",
+			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10,
 		}
@@ -452,7 +460,7 @@ func TestProduceContextCancellation(t *testing.T) {
 
 	msg := &wrp.Message{
 		Type:             wrp.SimpleEventMessageType,
-		Source:           "mac:112233445566",
+		Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 		Destination:      "event:test",
 		QualityOfService: 50,
 	}
@@ -475,7 +483,7 @@ func TestProduceNotStarted(t *testing.T) {
 
 	msg := &wrp.Message{
 		Type:             wrp.SimpleEventMessageType,
-		Source:           "mac:112233445566",
+		Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 		Destination:      "event:test",
 		QualityOfService: 50,
 	}
@@ -504,7 +512,7 @@ func TestProduce(t *testing.T) {
 			name: "low QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 10,
 			},
@@ -522,7 +530,7 @@ func TestProduce(t *testing.T) {
 			name: "low QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 0,
 			},
@@ -543,7 +551,7 @@ func TestProduce(t *testing.T) {
 			name: "medium QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -561,7 +569,7 @@ func TestProduce(t *testing.T) {
 			name: "medium QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 74,
 			},
@@ -583,7 +591,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 99,
 			},
@@ -603,7 +611,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 75,
 			},
@@ -626,7 +634,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS sync failure",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 80,
 			},
@@ -646,7 +654,7 @@ func TestProduce(t *testing.T) {
 			name: "QoS boundary values",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 24, // boundary between low and medium
 			},
@@ -664,7 +672,7 @@ func TestProduce(t *testing.T) {
 			name: "QoS boundary values - 25",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 25, // boundary between low and medium
 			},
@@ -682,7 +690,7 @@ func TestProduce(t *testing.T) {
 			name: "no topic match",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:nomatch",
 				QualityOfService: 50,
 			},
@@ -697,10 +705,10 @@ func TestProduce(t *testing.T) {
 			expectCalls:    map[string]int{},
 		},
 		{
-			name: "invalid device ID",
+			name: "invalid hash key",
 			msg: &wrp.Message{
-				Type:             wrp.SimpleEventMessageType,
-				Source:           "invalid-device-id",
+				Type: wrp.SimpleEventMessageType,
+				//Metadata:         map[string]string{"hw-deviceid": "invalid-device-id"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -711,14 +719,14 @@ func TestProduce(t *testing.T) {
 				// No calls expected
 			},
 			expectedResult: Failed,
-			expectedError:  "invalid device ID",
+			expectedError:  "hash key is empty",
 			expectCalls:    map[string]int{},
 		},
 		{
 			name: "invalid destination",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "invalid-destination",
 				QualityOfService: 50,
 			},
@@ -789,7 +797,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async retry exhausted error",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -807,7 +815,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async timeout error",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 60,
 			},
@@ -825,7 +833,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async success (no error)",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Source:           "mac:112233445566",
+				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 25,
 			},

--- a/topicroute.go
+++ b/topicroute.go
@@ -32,9 +32,7 @@ type TopicRoute struct {
 	TopicShardStrategy TopicShardStrategy
 
 	// HashKeyType specifies how to extract the hash key from the WRP message for sharding.
-	HashKeyType HashKeyType
-
-	MetadataKeyField string
+	HashKey HashKey
 
 	// counter is for internal use only - do not set manually.
 	// Tracks messages flowing through this route for round-robin distribution.
@@ -47,9 +45,8 @@ type TopicRoute struct {
 }
 
 type Topic struct {
-	Name        string
-	KeyType     HashKeyType
-	MetadataKey string
+	Name    string
+	HashKey HashKey
 }
 
 func (route *TopicRoute) compile() error {
@@ -115,21 +112,21 @@ func (route *TopicRoute) validate() error {
 func (r *TopicRoute) selectTopic(msg *wrp.Message) Topic {
 	// Single topic route (TopicShardNone)
 	if r.Topic != "" {
-		return Topic{Name: r.Topic, KeyType: r.HashKeyType, MetadataKey: r.MetadataKeyField}
+		return Topic{Name: r.Topic, HashKey: r.HashKey}
 	}
 
 	// Multi-topic sharding - delegate to strategy-specific methods
 	switch r.TopicShardStrategy {
 	case TopicShardRoundRobin:
-		return Topic{Name: r.selectRoundRobin(), KeyType: r.HashKeyType}
+		return Topic{Name: r.selectRoundRobin(), HashKey: r.HashKey}
 
 	case TopicShardDeviceID:
-		return Topic{Name: r.selectByDeviceID(msg), KeyType: r.HashKeyType}
+		return Topic{Name: r.selectByDeviceID(msg), HashKey: r.HashKey}
 
 	default:
 		// Check if it's a metadata strategy
 		if isMetadata, fieldName := r.TopicShardStrategy.IsMetadataStrategy(); isMetadata {
-			return Topic{Name: r.selectByMetadata(msg, fieldName), KeyType: r.HashKeyType, MetadataKey: r.MetadataKeyField}
+			return Topic{Name: r.selectByMetadata(msg, fieldName), HashKey: r.HashKey}
 		}
 	}
 
@@ -160,7 +157,7 @@ func (r *TopicRoute) selectByDeviceID(msg *wrp.Message) string {
 		return ""
 	}
 
-	deviceID, _ := GetHashKey(msg, r.HashKeyType, r.MetadataKeyField)
+	deviceID, _ := r.HashKey.GetHashKey(msg)
 	if deviceID == "" {
 		// Fall back to round-robin if device ID is missing
 		return r.selectRoundRobin()

--- a/topicroute.go
+++ b/topicroute.go
@@ -31,6 +31,9 @@ type TopicRoute struct {
 	// Empty string for single-topic routes (Topic field used).
 	TopicShardStrategy TopicShardStrategy
 
+	// HashKeyType specifies how to extract the hash key from the WRP message for sharding.
+	HashKeyType HashKeyType
+
 	// counter is for internal use only - do not set manually.
 	// Tracks messages flowing through this route for round-robin distribution.
 	// Automatically initialized for all multi-topic routes during validation.
@@ -39,6 +42,11 @@ type TopicRoute struct {
 	// matcher is for internal use only - do not set manually.
 	// Compiled pattern matcher initialized during configuration validation.
 	matcher *patternMatcher
+}
+
+type Topic struct {
+	Name string
+	Key  HashKeyType
 }
 
 func (route *TopicRoute) compile() error {
@@ -101,28 +109,28 @@ func (route *TopicRoute) validate() error {
 
 // selectTopic selects the appropriate Kafka topic for a message based on the routing rule.
 // Supports single-topic routes and multi-topic sharding strategies.
-func (r *TopicRoute) selectTopic(msg *wrp.Message) string {
+func (r *TopicRoute) selectTopic(msg *wrp.Message) Topic {
 	// Single topic route (TopicShardNone)
 	if r.Topic != "" {
-		return r.Topic
+		return Topic{Name: r.Topic, Key: r.HashKeyType}
 	}
 
 	// Multi-topic sharding - delegate to strategy-specific methods
 	switch r.TopicShardStrategy {
 	case TopicShardRoundRobin:
-		return r.selectRoundRobin()
+		return Topic{Name: r.selectRoundRobin(), Key: r.HashKeyType}
 
 	case TopicShardDeviceID:
-		return r.selectByDeviceID(msg)
+		return Topic{Name: r.selectByDeviceID(msg), Key: r.HashKeyType}
 
 	default:
 		// Check if it's a metadata strategy
 		if isMetadata, fieldName := r.TopicShardStrategy.IsMetadataStrategy(); isMetadata {
-			return r.selectByMetadata(msg, fieldName)
+			return Topic{Name: r.selectByMetadata(msg, fieldName), Key: r.HashKeyType}
 		}
 	}
 
-	return ""
+	return Topic{}
 }
 
 // selectRoundRobin selects a topic using round-robin distribution.
@@ -141,7 +149,7 @@ func (r *TopicRoute) selectRoundRobin() string {
 	return r.Topics[idx]
 }
 
-// selectByDeviceID selects a topic by hashing the device ID from WRP Source field.
+// selectByDeviceID selects a topic by hashing the device ID from WRP device id metadata field.
 // Falls back to round-robin if the device ID is missing or empty.
 // Returns empty string if no topics are configured.
 func (r *TopicRoute) selectByDeviceID(msg *wrp.Message) string {
@@ -149,7 +157,7 @@ func (r *TopicRoute) selectByDeviceID(msg *wrp.Message) string {
 		return ""
 	}
 
-	deviceID := msg.Source
+	deviceID, _ := GetHashKey(msg, HashKeyDeviceID)
 	if deviceID == "" {
 		// Fall back to round-robin if device ID is missing
 		return r.selectRoundRobin()

--- a/topicroute.go
+++ b/topicroute.go
@@ -34,6 +34,8 @@ type TopicRoute struct {
 	// HashKeyType specifies how to extract the hash key from the WRP message for sharding.
 	HashKeyType HashKeyType
 
+	MetadataKeyField string
+
 	// counter is for internal use only - do not set manually.
 	// Tracks messages flowing through this route for round-robin distribution.
 	// Automatically initialized for all multi-topic routes during validation.
@@ -45,8 +47,9 @@ type TopicRoute struct {
 }
 
 type Topic struct {
-	Name string
-	Key  HashKeyType
+	Name        string
+	KeyType     HashKeyType
+	MetadataKey string
 }
 
 func (route *TopicRoute) compile() error {
@@ -112,21 +115,21 @@ func (route *TopicRoute) validate() error {
 func (r *TopicRoute) selectTopic(msg *wrp.Message) Topic {
 	// Single topic route (TopicShardNone)
 	if r.Topic != "" {
-		return Topic{Name: r.Topic, Key: r.HashKeyType}
+		return Topic{Name: r.Topic, KeyType: r.HashKeyType, MetadataKey: r.MetadataKeyField}
 	}
 
 	// Multi-topic sharding - delegate to strategy-specific methods
 	switch r.TopicShardStrategy {
 	case TopicShardRoundRobin:
-		return Topic{Name: r.selectRoundRobin(), Key: r.HashKeyType}
+		return Topic{Name: r.selectRoundRobin(), KeyType: r.HashKeyType}
 
 	case TopicShardDeviceID:
-		return Topic{Name: r.selectByDeviceID(msg), Key: r.HashKeyType}
+		return Topic{Name: r.selectByDeviceID(msg), KeyType: r.HashKeyType}
 
 	default:
 		// Check if it's a metadata strategy
 		if isMetadata, fieldName := r.TopicShardStrategy.IsMetadataStrategy(); isMetadata {
-			return Topic{Name: r.selectByMetadata(msg, fieldName), Key: r.HashKeyType}
+			return Topic{Name: r.selectByMetadata(msg, fieldName), KeyType: r.HashKeyType, MetadataKey: r.MetadataKeyField}
 		}
 	}
 
@@ -157,7 +160,7 @@ func (r *TopicRoute) selectByDeviceID(msg *wrp.Message) string {
 		return ""
 	}
 
-	deviceID, _ := GetHashKey(msg, HashKeyDeviceID)
+	deviceID, _ := GetHashKey(msg, r.HashKeyType, r.MetadataKeyField)
 	if deviceID == "" {
 		// Fall back to round-robin if device ID is missing
 		return r.selectRoundRobin()

--- a/topicroute_test.go
+++ b/topicroute_test.go
@@ -195,7 +195,10 @@ func TestSelectByDeviceID(t *testing.T) {
 				counter: &atomic.Uint64{},
 			}
 
-			msg := &wrp.Message{Source: tt.deviceID}
+			msg := &wrp.Message{}
+			if tt.deviceID != "" {
+				msg.Metadata = map[string]string{MetadataKeyDeviceID: tt.deviceID}
+			}
 			got := route.selectByDeviceID(msg)
 
 			assert.Equal(t, tt.want, got)
@@ -284,7 +287,7 @@ func TestSelectTopic(t *testing.T) {
 		route  TopicRoute
 		msg    *wrp.Message
 		want   string
-		verify func(t *testing.T, route *TopicRoute, got string)
+		verify func(t *testing.T, route *TopicRoute, got Topic)
 	}{
 		{
 			name: "single topic route",
@@ -312,10 +315,10 @@ func TestSelectTopic(t *testing.T) {
 				counter:            &atomic.Uint64{},
 			},
 			msg: &wrp.Message{Source: "mac:112233445566"},
-			verify: func(t *testing.T, route *TopicRoute, got string) {
-				assert.NotEmpty(t, got)
+			verify: func(t *testing.T, route *TopicRoute, got Topic) {
+				assert.NotEmpty(t, got.Name)
 				// Verify it's one of the configured topics
-				assert.Contains(t, route.Topics, got)
+				assert.Contains(t, route.Topics, got.Name)
 			},
 		},
 		{
@@ -329,9 +332,9 @@ func TestSelectTopic(t *testing.T) {
 				Source:   "mac:112233445566",
 				Metadata: map[string]string{"region": "us-west"},
 			},
-			verify: func(t *testing.T, route *TopicRoute, got string) {
-				assert.NotEmpty(t, got)
-				assert.Contains(t, route.Topics, got)
+			verify: func(t *testing.T, route *TopicRoute, got Topic) {
+				assert.NotEmpty(t, got.Name)
+				assert.Contains(t, route.Topics, got.Name)
 			},
 		},
 		{
@@ -354,7 +357,7 @@ func TestSelectTopic(t *testing.T) {
 			if tt.verify != nil {
 				tt.verify(t, &tt.route, got)
 			} else {
-				assert.Equal(t, tt.want, got)
+				assert.Equal(t, tt.want, got.Name)
 			}
 		})
 	}

--- a/topicroute_test.go
+++ b/topicroute_test.go
@@ -23,8 +23,10 @@ func TestTopicRoute_Validate(t *testing.T) {
 		{
 			name: "valid single topic",
 			route: TopicRoute{
-				Pattern: "event.type",
-				Topic:   "my-topic",
+				Pattern:          "event.type",
+				Topic:            "my-topic",
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			wantErr: false,
 		},
@@ -34,23 +36,29 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.*",
 				Topics:             []string{"topic-1", "topic-2"},
 				TopicShardStrategy: TopicShardRoundRobin,
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid empty pattern",
 			route: TopicRoute{
-				Pattern: "",
-				Topic:   "my-topic",
+				Pattern:          "",
+				Topic:            "my-topic",
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid both topic and topics set",
 			route: TopicRoute{
-				Pattern: "event.type",
-				Topic:   "my-topic",
-				Topics:  []string{"topic-1", "topic-2"},
+				Pattern:          "event.type",
+				Topic:            "my-topic",
+				Topics:           []string{"topic-1", "topic-2"},
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
@@ -60,21 +68,27 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.type",
 				Topic:              "my-topic",
 				TopicShardStrategy: TopicShardRoundRobin,
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid multi-topic missing shard strategy",
 			route: TopicRoute{
-				Pattern: "event.*",
-				Topics:  []string{"topic-1", "topic-2"},
+				Pattern:          "event.*",
+				Topics:           []string{"topic-1", "topic-2"},
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid no topics or topic",
 			route: TopicRoute{
-				Pattern: "event.type",
+				Pattern:          "event.type",
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
@@ -84,6 +98,8 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.*",
 				Topics:             []string{"topic-1", "topic-2"},
 				TopicShardStrategy: "unknownstrategy",
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			wantErr: true,
 		},
@@ -138,8 +154,10 @@ func TestSelectRoundRobin(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:  tt.topics,
-				counter: &atomic.Uint64{},
+				Topics:           tt.topics,
+				counter:          &atomic.Uint64{},
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			}
 
 			for i := 0; i < tt.calls; i++ {
@@ -191,13 +209,15 @@ func TestSelectByDeviceID(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:  tt.topics,
-				counter: &atomic.Uint64{},
+				Topics:           tt.topics,
+				counter:          &atomic.Uint64{},
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			}
 
 			msg := &wrp.Message{}
 			if tt.deviceID != "" {
-				msg.Metadata = map[string]string{MetadataKeyDeviceID: tt.deviceID}
+				msg.Metadata = map[string]string{DefaultMetadataKeyField: tt.deviceID}
 			}
 			got := route.selectByDeviceID(msg)
 
@@ -266,8 +286,10 @@ func TestSelectByMetadata(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:  tt.topics,
-				counter: &atomic.Uint64{},
+				Topics:           tt.topics,
+				counter:          &atomic.Uint64{},
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			}
 
 			msg := &wrp.Message{Metadata: tt.metadata}
@@ -292,7 +314,9 @@ func TestSelectTopic(t *testing.T) {
 		{
 			name: "single topic route",
 			route: TopicRoute{
-				Topic: "my-topic",
+				Topic:            "my-topic",
+				HashKeyType:      HashKeyMetadata,
+				MetadataKeyField: DefaultMetadataKeyField,
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "my-topic",
@@ -303,6 +327,8 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: TopicShardRoundRobin,
 				counter:            &atomic.Uint64{},
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "topic-0",
@@ -313,6 +339,8 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1", "topic-2"},
 				TopicShardStrategy: TopicShardDeviceID,
 				counter:            &atomic.Uint64{},
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			msg: &wrp.Message{Source: "mac:112233445566"},
 			verify: func(t *testing.T, route *TopicRoute, got Topic) {
@@ -327,6 +355,8 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: "metadata:region",
 				counter:            &atomic.Uint64{},
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			msg: &wrp.Message{
 				Source:   "mac:112233445566",
@@ -343,6 +373,8 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: "unknown-strategy",
 				counter:            &atomic.Uint64{},
+				HashKeyType:        HashKeyMetadata,
+				MetadataKeyField:   DefaultMetadataKeyField,
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "",
@@ -368,8 +400,10 @@ func TestSelectRoundRobin_Concurrency(t *testing.T) {
 	t.Parallel()
 
 	route := &TopicRoute{
-		Topics:  []string{"topic-0", "topic-1", "topic-2"},
-		counter: &atomic.Uint64{},
+		Topics:           []string{"topic-0", "topic-1", "topic-2"},
+		counter:          &atomic.Uint64{},
+		HashKeyType:      HashKeyMetadata,
+		MetadataKeyField: DefaultMetadataKeyField,
 	}
 
 	const goroutines = 10

--- a/topicroute_test.go
+++ b/topicroute_test.go
@@ -23,10 +23,9 @@ func TestTopicRoute_Validate(t *testing.T) {
 		{
 			name: "valid single topic",
 			route: TopicRoute{
-				Pattern:          "event.type",
-				Topic:            "my-topic",
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Pattern: "event.type",
+				Topic:   "my-topic",
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: false,
 		},
@@ -36,29 +35,26 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.*",
 				Topics:             []string{"topic-1", "topic-2"},
 				TopicShardStrategy: TopicShardRoundRobin,
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid empty pattern",
 			route: TopicRoute{
-				Pattern:          "",
-				Topic:            "my-topic",
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Pattern: "",
+				Topic:   "my-topic",
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid both topic and topics set",
 			route: TopicRoute{
-				Pattern:          "event.type",
-				Topic:            "my-topic",
-				Topics:           []string{"topic-1", "topic-2"},
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Pattern: "event.type",
+				Topic:   "my-topic",
+				Topics:  []string{"topic-1", "topic-2"},
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
@@ -68,27 +64,24 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.type",
 				Topic:              "my-topic",
 				TopicShardStrategy: TopicShardRoundRobin,
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid multi-topic missing shard strategy",
 			route: TopicRoute{
-				Pattern:          "event.*",
-				Topics:           []string{"topic-1", "topic-2"},
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Pattern: "event.*",
+				Topics:  []string{"topic-1", "topic-2"},
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid no topics or topic",
 			route: TopicRoute{
-				Pattern:          "event.type",
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Pattern: "event.type",
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
@@ -98,8 +91,7 @@ func TestTopicRoute_Validate(t *testing.T) {
 				Pattern:            "event.*",
 				Topics:             []string{"topic-1", "topic-2"},
 				TopicShardStrategy: "unknownstrategy",
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			wantErr: true,
 		},
@@ -154,10 +146,9 @@ func TestSelectRoundRobin(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:           tt.topics,
-				counter:          &atomic.Uint64{},
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Topics:  tt.topics,
+				counter: &atomic.Uint64{},
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			}
 
 			for i := 0; i < tt.calls; i++ {
@@ -209,10 +200,9 @@ func TestSelectByDeviceID(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:           tt.topics,
-				counter:          &atomic.Uint64{},
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Topics:  tt.topics,
+				counter: &atomic.Uint64{},
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			}
 
 			msg := &wrp.Message{}
@@ -286,10 +276,9 @@ func TestSelectByMetadata(t *testing.T) {
 			t.Parallel()
 
 			route := &TopicRoute{
-				Topics:           tt.topics,
-				counter:          &atomic.Uint64{},
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Topics:  tt.topics,
+				counter: &atomic.Uint64{},
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			}
 
 			msg := &wrp.Message{Metadata: tt.metadata}
@@ -314,9 +303,8 @@ func TestSelectTopic(t *testing.T) {
 		{
 			name: "single topic route",
 			route: TopicRoute{
-				Topic:            "my-topic",
-				HashKeyType:      HashKeyMetadata,
-				MetadataKeyField: DefaultMetadataKeyField,
+				Topic:   "my-topic",
+				HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "my-topic",
@@ -327,8 +315,7 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: TopicShardRoundRobin,
 				counter:            &atomic.Uint64{},
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "topic-0",
@@ -339,8 +326,7 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1", "topic-2"},
 				TopicShardStrategy: TopicShardDeviceID,
 				counter:            &atomic.Uint64{},
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			msg: &wrp.Message{Source: "mac:112233445566"},
 			verify: func(t *testing.T, route *TopicRoute, got Topic) {
@@ -355,8 +341,7 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: "metadata:region",
 				counter:            &atomic.Uint64{},
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			msg: &wrp.Message{
 				Source:   "mac:112233445566",
@@ -373,8 +358,7 @@ func TestSelectTopic(t *testing.T) {
 				Topics:             []string{"topic-0", "topic-1"},
 				TopicShardStrategy: "unknown-strategy",
 				counter:            &atomic.Uint64{},
-				HashKeyType:        HashKeyMetadata,
-				MetadataKeyField:   DefaultMetadataKeyField,
+				HashKey:            HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 			},
 			msg:  &wrp.Message{Source: "mac:112233445566"},
 			want: "",
@@ -400,10 +384,9 @@ func TestSelectRoundRobin_Concurrency(t *testing.T) {
 	t.Parallel()
 
 	route := &TopicRoute{
-		Topics:           []string{"topic-0", "topic-1", "topic-2"},
-		counter:          &atomic.Uint64{},
-		HashKeyType:      HashKeyMetadata,
-		MetadataKeyField: DefaultMetadataKeyField,
+		Topics:  []string{"topic-0", "topic-1", "topic-2"},
+		counter: &atomic.Uint64{},
+		HashKey: HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField},
 	}
 
 	const goroutines = 10


### PR DESCRIPTION
supposedly hw-deviceid is always populated, at least it looks to be that way in talaria code

hash key is configurable by topic-route