### PR TITLE
do not automatically reject messages without partition keys

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -509,10 +509,10 @@ func TestToKgoOpts(t *testing.T) {
 			},
 		},
 		{
-			name: "allow nil partition keys",
+			name: "deny nil partition keys",
 			publisher: &Publisher{
-				Brokers:              []string{"localhost:9092"},
-				AllowNilPartitionKey: true,
+				Brokers:             []string{"localhost:9092"},
+				DenyNilPartitionKey: true,
 			},
 		},
 		{

--- a/config_test.go
+++ b/config_test.go
@@ -509,6 +509,13 @@ func TestToKgoOpts(t *testing.T) {
 			},
 		},
 		{
+			name: "allow nil partition keys",
+			publisher: &Publisher{
+				Brokers:              []string{"localhost:9092"},
+				AllowNilPartitionKey: true,
+			},
+		},
+		{
 			name: "all options",
 			publisher: &Publisher{
 				Brokers: []string{"localhost:9092"},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.2
 
 require (
 	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.42.0
 	github.com/twmb/franz-go v1.20.7
 	github.com/twmb/franz-go/plugin/kprom v1.3.0
@@ -60,7 +61,6 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tinylib/msgp v1.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ package wrpkafka_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -140,11 +141,14 @@ func TestIntegration_TopicRouting(t *testing.T) {
 	t.Parallel()
 	_, broker := setupKafka(t)
 
+	// Use unique topic names with random component to avoid contamination
+	topicPrefix := fmt.Sprintf("test-%d-%d-", time.Now().UnixNano(), rand.Int63())
+
 	pub := createTestPublisher(t, broker, []wrpkafka.TopicRoute{
-		{Pattern: "online", Topic: "lifecycle-events"},
-		{Pattern: "offline", Topic: "lifecycle-events"},
-		{Pattern: "device-*", Topic: "device-events"},
-		{Pattern: "*", Topic: "default-events"},
+		{Pattern: "online", Topic: topicPrefix + "lifecycle-events"},
+		{Pattern: "offline", Topic: topicPrefix + "lifecycle-events"},
+		{Pattern: "device-*", Topic: topicPrefix + "device-events"},
+		{Pattern: "*", Topic: topicPrefix + "default-events"},
 	})
 
 	err := pub.Start()
@@ -155,11 +159,11 @@ func TestIntegration_TopicRouting(t *testing.T) {
 		eventType     string
 		expectedTopic string
 	}{
-		{"online", "lifecycle-events"},
-		{"offline", "lifecycle-events"},
-		{"device-status", "device-events"},
-		{"device-config", "device-events"},
-		{"unknown-event", "default-events"},
+		{"online", topicPrefix + "lifecycle-events"},
+		{"offline", topicPrefix + "lifecycle-events"},
+		{"device-status", topicPrefix + "device-events"},
+		{"device-config", topicPrefix + "device-events"},
+		{"unknown-event", topicPrefix + "default-events"},
 	}
 
 	for i, tt := range tests {
@@ -201,10 +205,13 @@ func TestIntegration_RoundRobinSharding(t *testing.T) {
 	t.Parallel()
 	_, broker := setupKafka(t)
 
+	// Use unique topic names with random component to avoid contamination
+	topicPrefix := fmt.Sprintf("shard-%d-%d-", time.Now().UnixNano(), rand.Int63())
+
 	pub := createTestPublisher(t, broker, []wrpkafka.TopicRoute{
 		{
 			Pattern:            "*",
-			Topics:             []string{"shard-0", "shard-1", "shard-2"},
+			Topics:             []string{topicPrefix + "0", topicPrefix + "1", topicPrefix + "2"},
 			TopicShardStrategy: wrpkafka.TopicShardRoundRobin,
 		},
 	})
@@ -223,9 +230,9 @@ func TestIntegration_RoundRobinSharding(t *testing.T) {
 	}
 
 	// Verify distribution across shards
-	shard0 := consumeMessages(t, broker, "shard-0", messageConsumeWait)
-	shard1 := consumeMessages(t, broker, "shard-1", messageConsumeWait)
-	shard2 := consumeMessages(t, broker, "shard-2", messageConsumeWait)
+	shard0 := consumeMessages(t, broker, topicPrefix+"0", messageConsumeWait)
+	shard1 := consumeMessages(t, broker, topicPrefix+"1", messageConsumeWait)
+	shard2 := consumeMessages(t, broker, topicPrefix+"2", messageConsumeWait)
 
 	t.Logf("Distribution: shard-0=%d, shard-1=%d, shard-2=%d", len(shard0), len(shard1), len(shard2))
 
@@ -478,54 +485,27 @@ func TestIntegration_StartStopMultipleTimes(t *testing.T) {
 	assert.GreaterOrEqual(t, len(records), 2, "Expected at least 2 messages")
 }
 
-// TestIntegration_AllowNilPartitionKey tests the AllowNilPartitionKey configuration.
+// TestIntegration_DenyNilPartitionKey tests the DenyNilPartitionKey configuration.
 //
 // Verifies:
-// - With AllowNilPartitionKey=false, publishing fails when partition key cannot be extracted
-// - With AllowNilPartitionKey=true, publishing succeeds with nil keys
+// - With DenyNilPartitionKey=false (default), publishing succeeds with nil keys
+// - With DenyNilPartitionKey=true, publishing fails when partition key cannot be extracted
 // - When partition key is present, it's always used regardless of config
-func TestIntegration_AllowNilPartitionKey(t *testing.T) {
+func TestIntegration_DenyNilPartitionKey(t *testing.T) {
 	t.Parallel()
 	_, broker := setupKafka(t)
 
-	t.Run("default behavior rejects missing keys", func(t *testing.T) {
+	t.Run("default behavior allows missing keys", func(t *testing.T) {
+		// Use unique topic name with random component to avoid collisions
+		topic := fmt.Sprintf("test-%d-%d-default-allows", time.Now().UnixNano(), rand.Int63())
+
 		pub := &wrpkafka.Publisher{
 			Brokers:                []string{broker},
 			AllowAutoTopicCreation: true,
-			AllowNilPartitionKey:   false, // Explicitly false (default)
+			DenyNilPartitionKey:    false, // Explicitly false (default)
 			InitialDynamicConfig: wrpkafka.DynamicConfig{
 				TopicMap: []wrpkafka.TopicRoute{
-					{Pattern: "*", Topic: "reject-nil-keys"},
-				},
-			},
-		}
-
-		err := pub.Start()
-		require.NoError(t, err)
-		defer pub.Stop(context.Background())
-
-		// Create message without metadata (partition key will fail to extract)
-		msgWithoutKey := &wrp.Message{
-			Type:        wrp.SimpleEventMessageType,
-			Source:      "", // Empty source
-			Destination: "event:test-event",
-			Payload:     []byte("test"),
-			Metadata:    nil, // No metadata
-		}
-
-		// Should fail because partition key is missing and AllowNilPartitionKey=false
-		_, err = pub.Produce(context.Background(), msgWithoutKey)
-		assert.Error(t, err, "Should fail when partition key is missing and AllowNilPartitionKey=false")
-	})
-
-	t.Run("allow nil keys when configured", func(t *testing.T) {
-		pub := &wrpkafka.Publisher{
-			Brokers:                []string{broker},
-			AllowAutoTopicCreation: true,
-			AllowNilPartitionKey:   true, // Allow nil partition keys
-			InitialDynamicConfig: wrpkafka.DynamicConfig{
-				TopicMap: []wrpkafka.TopicRoute{
-					{Pattern: "*", Topic: "allow-nil-keys"},
+					{Pattern: "*", Topic: topic},
 				},
 			},
 		}
@@ -536,6 +516,50 @@ func TestIntegration_AllowNilPartitionKey(t *testing.T) {
 
 		// Create message without metadata (partition key will be nil)
 		msgWithoutKey := &wrp.Message{
+			Type:             wrp.SimpleEventMessageType,
+			Source:           "", // Empty source
+			Destination:      "event:test-event",
+			Payload:          []byte("test"),
+			Metadata:         nil, // No metadata
+			QualityOfService: 75,  // QoS 75-99 for synchronous delivery
+		}
+
+		// Should succeed with nil partition key (default behavior)
+		outcome, err := pub.Produce(context.Background(), msgWithoutKey)
+		require.NoError(t, err)
+		assert.Equal(t, wrpkafka.Accepted, outcome)
+
+		// Small delay to ensure message is committed
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify message in Kafka with nil key
+		records := consumeMessages(t, broker, topic, messageConsumeWait)
+		t.Logf("Topic %s: received %d messages", topic, len(records))
+		for i, r := range records {
+			t.Logf("  Message %d: key=%v, partition=%d, offset=%d", i, r.Key, r.Partition, r.Offset)
+		}
+		require.Len(t, records, 1, "Expected 1 message")
+		assert.Nil(t, records[0].Key, "Partition key should be nil")
+	})
+
+	t.Run("deny nil keys when configured", func(t *testing.T) {
+		pub := &wrpkafka.Publisher{
+			Brokers:                []string{broker},
+			AllowAutoTopicCreation: true,
+			DenyNilPartitionKey:    true, // Deny nil partition keys
+			InitialDynamicConfig: wrpkafka.DynamicConfig{
+				TopicMap: []wrpkafka.TopicRoute{
+					{Pattern: "*", Topic: "deny-nil-keys"},
+				},
+			},
+		}
+
+		err := pub.Start()
+		require.NoError(t, err)
+		defer pub.Stop(context.Background())
+
+		// Create message without metadata (partition key will fail)
+		msgWithoutKey := &wrp.Message{
 			Type:        wrp.SimpleEventMessageType,
 			Source:      "", // Empty source
 			Destination: "event:test-event",
@@ -543,29 +567,22 @@ func TestIntegration_AllowNilPartitionKey(t *testing.T) {
 			Metadata:    nil, // No metadata
 		}
 
-		// Should succeed with nil partition key
-		outcome, err := pub.Produce(context.Background(), msgWithoutKey)
-		require.NoError(t, err)
-		assert.Equal(t, wrpkafka.Accepted, outcome)
-
-		// Verify message in Kafka with nil key
-		records := consumeMessages(t, broker, "allow-nil-keys", messageConsumeWait)
-		require.Len(t, records, 1, "Expected 1 message")
-		assert.Nil(t, records[0].Key, "Partition key should be nil")
-
-		// Verify payload
-		decoded := decodeWRPMessage(t, records[0])
-		assert.Equal(t, string(msgWithoutKey.Payload), string(decoded.Payload))
+		// Should fail because partition key is missing and DenyNilPartitionKey=true
+		_, err = pub.Produce(context.Background(), msgWithoutKey)
+		assert.Error(t, err, "Should fail when partition key is missing and DenyNilPartitionKey=true")
 	})
 
-	t.Run("uses partition key when present even with AllowNilPartitionKey=true", func(t *testing.T) {
+	t.Run("uses partition key when present regardless of DenyNilPartitionKey", func(t *testing.T) {
+		// Use unique topic name with random component to avoid collisions
+		topic := fmt.Sprintf("test-%d-%d-prefer-keys", time.Now().UnixNano(), rand.Int63())
+
 		pub := &wrpkafka.Publisher{
 			Brokers:                []string{broker},
 			AllowAutoTopicCreation: true,
-			AllowNilPartitionKey:   true, // Allow nil, but use key if present
+			DenyNilPartitionKey:    false, // Allow nil, but use key if present
 			InitialDynamicConfig: wrpkafka.DynamicConfig{
 				TopicMap: []wrpkafka.TopicRoute{
-					{Pattern: "*", Topic: "prefer-keys"},
+					{Pattern: "*", Topic: topic},
 				},
 			},
 		}
@@ -581,8 +598,8 @@ func TestIntegration_AllowNilPartitionKey(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, wrpkafka.Accepted, outcome)
 
-		// Verify message uses the partition key even though AllowNilPartitionKey=true
-		records := consumeMessages(t, broker, "prefer-keys", messageConsumeWait)
+		// Verify message uses the partition key regardless of DenyNilPartitionKey setting
+		records := consumeMessages(t, broker, topic, messageConsumeWait)
 		require.Len(t, records, 1, "Expected 1 message")
 		assert.NotNil(t, records[0].Key, "Partition key should not be nil when available")
 		assert.Equal(t, "mac:112233445566", string(records[0].Key), "Should use partition key from message")

--- a/integration_test.go
+++ b/integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xmidt-org/wrp-go/v5"
 	"github.com/xmidt-org/wrpkafka"
 )
 
@@ -475,4 +476,115 @@ func TestIntegration_StartStopMultipleTimes(t *testing.T) {
 	// Verify both messages arrived
 	records := consumeMessages(t, broker, "lifecycle-test", messageConsumeWait)
 	assert.GreaterOrEqual(t, len(records), 2, "Expected at least 2 messages")
+}
+
+// TestIntegration_AllowNilPartitionKey tests the AllowNilPartitionKey configuration.
+//
+// Verifies:
+// - With AllowNilPartitionKey=false, publishing fails when partition key cannot be extracted
+// - With AllowNilPartitionKey=true, publishing succeeds with nil keys
+// - When partition key is present, it's always used regardless of config
+func TestIntegration_AllowNilPartitionKey(t *testing.T) {
+	t.Parallel()
+	_, broker := setupKafka(t)
+
+	t.Run("default behavior rejects missing keys", func(t *testing.T) {
+		pub := &wrpkafka.Publisher{
+			Brokers:                []string{broker},
+			AllowAutoTopicCreation: true,
+			AllowNilPartitionKey:   false, // Explicitly false (default)
+			InitialDynamicConfig: wrpkafka.DynamicConfig{
+				TopicMap: []wrpkafka.TopicRoute{
+					{Pattern: "*", Topic: "reject-nil-keys"},
+				},
+			},
+		}
+
+		err := pub.Start()
+		require.NoError(t, err)
+		defer pub.Stop(context.Background())
+
+		// Create message without metadata (partition key will fail to extract)
+		msgWithoutKey := &wrp.Message{
+			Type:        wrp.SimpleEventMessageType,
+			Source:      "", // Empty source
+			Destination: "event:test-event",
+			Payload:     []byte("test"),
+			Metadata:    nil, // No metadata
+		}
+
+		// Should fail because partition key is missing and AllowNilPartitionKey=false
+		_, err = pub.Produce(context.Background(), msgWithoutKey)
+		assert.Error(t, err, "Should fail when partition key is missing and AllowNilPartitionKey=false")
+	})
+
+	t.Run("allow nil keys when configured", func(t *testing.T) {
+		pub := &wrpkafka.Publisher{
+			Brokers:                []string{broker},
+			AllowAutoTopicCreation: true,
+			AllowNilPartitionKey:   true, // Allow nil partition keys
+			InitialDynamicConfig: wrpkafka.DynamicConfig{
+				TopicMap: []wrpkafka.TopicRoute{
+					{Pattern: "*", Topic: "allow-nil-keys"},
+				},
+			},
+		}
+
+		err := pub.Start()
+		require.NoError(t, err)
+		defer pub.Stop(context.Background())
+
+		// Create message without metadata (partition key will be nil)
+		msgWithoutKey := &wrp.Message{
+			Type:        wrp.SimpleEventMessageType,
+			Source:      "", // Empty source
+			Destination: "event:test-event",
+			Payload:     []byte("test-without-key"),
+			Metadata:    nil, // No metadata
+		}
+
+		// Should succeed with nil partition key
+		outcome, err := pub.Produce(context.Background(), msgWithoutKey)
+		require.NoError(t, err)
+		assert.Equal(t, wrpkafka.Accepted, outcome)
+
+		// Verify message in Kafka with nil key
+		records := consumeMessages(t, broker, "allow-nil-keys", messageConsumeWait)
+		require.Len(t, records, 1, "Expected 1 message")
+		assert.Nil(t, records[0].Key, "Partition key should be nil")
+
+		// Verify payload
+		decoded := decodeWRPMessage(t, records[0])
+		assert.Equal(t, string(msgWithoutKey.Payload), string(decoded.Payload))
+	})
+
+	t.Run("uses partition key when present even with AllowNilPartitionKey=true", func(t *testing.T) {
+		pub := &wrpkafka.Publisher{
+			Brokers:                []string{broker},
+			AllowAutoTopicCreation: true,
+			AllowNilPartitionKey:   true, // Allow nil, but use key if present
+			InitialDynamicConfig: wrpkafka.DynamicConfig{
+				TopicMap: []wrpkafka.TopicRoute{
+					{Pattern: "*", Topic: "prefer-keys"},
+				},
+			},
+		}
+
+		err := pub.Start()
+		require.NoError(t, err)
+		defer pub.Stop(context.Background())
+
+		// Create message WITH valid partition key
+		msgWithKey := createTestMessage("test-event", "mac:112233445566", 75)
+
+		outcome, err := pub.Produce(context.Background(), msgWithKey)
+		require.NoError(t, err)
+		assert.Equal(t, wrpkafka.Accepted, outcome)
+
+		// Verify message uses the partition key even though AllowNilPartitionKey=true
+		records := consumeMessages(t, broker, "prefer-keys", messageConsumeWait)
+		require.Len(t, records, 1, "Expected 1 message")
+		assert.NotNil(t, records[0].Key, "Partition key should not be nil when available")
+		assert.Equal(t, "mac:112233445566", string(records[0].Key), "Should use partition key from message")
+	})
 }

--- a/publisher.go
+++ b/publisher.go
@@ -127,6 +127,14 @@ type Publisher struct {
 	// Optional. Default: "" (no subsystem).
 	PrometheusSubsystem string
 
+	// AllowNilPartitionKey allows records to have nil partition keys when the hash key
+	// cannot be extracted from the message (missing or empty).
+	// When false (default), publishing fails if the partition key is missing/empty.
+	// When true, records use nil keys and rely on Kafka's default partitioner for
+	// round-robin distribution across partitions.
+	// Optional. Default: false (require valid partition keys).
+	AllowNilPartitionKey bool
+
 	// --- INTERNAL FIELDS (not for user configuration) ---
 
 	// logger is for internal use only.
@@ -419,18 +427,31 @@ func (p *Publisher) buildRecords(msg *wrp.Message) ([]*kgo.Record, []TopicShardS
 	// Create records for each topic
 	records := make([]*kgo.Record, 0, len(topics))
 	for _, topic := range topics {
+		// Always try to get partition key from message
 		partitionKey, err := topic.HashKey.GetHashKey(msg)
-		if err != nil {
-			return nil, nil,
-				errors.Join(
-					ErrValidation,
-					fmt.Errorf("invalid hash key in WRP message `%v`", msg.Metadata),
-					err,
-				)
+
+		// Determine the key to use
+		var key []byte
+		if err != nil || partitionKey == "" {
+			// Key extraction failed or returned empty
+			if !p.AllowNilPartitionKey {
+				// Nil keys not allowed - return error
+				return nil, nil,
+					errors.Join(
+						ErrValidation,
+						fmt.Errorf("invalid hash key in WRP message `%v`", msg.Metadata),
+						err,
+					)
+			}
+			// Nil keys allowed - key remains nil for round-robin distribution
+		} else {
+			// Successfully got partition key from message
+			key = []byte(partitionKey)
 		}
+
 		record := &kgo.Record{
 			Topic:   topic.Name,
-			Key:     []byte(partitionKey),
+			Key:     key,
 			Value:   encoded,
 			Headers: dynCfg.headers(msg),
 		}

--- a/publisher.go
+++ b/publisher.go
@@ -127,13 +127,13 @@ type Publisher struct {
 	// Optional. Default: "" (no subsystem).
 	PrometheusSubsystem string
 
-	// AllowNilPartitionKey allows records to have nil partition keys when the hash key
+	// DenyNilPartitionKey requires valid partition keys and fails publishing when the hash key
 	// cannot be extracted from the message (missing or empty).
-	// When false (default), publishing fails if the partition key is missing/empty.
-	// When true, records use nil keys and rely on Kafka's default partitioner for
-	// round-robin distribution across partitions.
-	// Optional. Default: false (require valid partition keys).
-	AllowNilPartitionKey bool
+	// When false (default), records can have nil keys and rely on Kafka's default partitioner
+	// for round-robin distribution across partitions.
+	// When true, publishing fails if the partition key is missing/empty.
+	// Optional. Default: false (allow nil partition keys).
+	DenyNilPartitionKey bool
 
 	// --- INTERNAL FIELDS (not for user configuration) ---
 
@@ -434,8 +434,8 @@ func (p *Publisher) buildRecords(msg *wrp.Message) ([]*kgo.Record, []TopicShardS
 		var key []byte
 		if err != nil || partitionKey == "" {
 			// Key extraction failed or returned empty
-			if !p.AllowNilPartitionKey {
-				// Nil keys not allowed - return error
+			if p.DenyNilPartitionKey {
+				// Nil keys denied - return error
 				return nil, nil,
 					errors.Join(
 						ErrValidation,

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -225,6 +225,7 @@ func TestProduceErrors(t *testing.T) {
 	t.Run("missing hash key", func(t *testing.T) {
 		t.Parallel()
 		p := newTestPublisher(DynamicConfig{TopicMap: []TopicRoute{{Pattern: "*", Topic: "t"}}})
+		p.DenyNilPartitionKey = true // Require valid partition keys
 		p.clientMu.Lock()
 		p.client = &mockKafkaClient{}
 		p.clientMu.Unlock()
@@ -504,6 +505,7 @@ func TestProduce(t *testing.T) {
 		msg            *wrp.Message
 		dynamicConfig  DynamicConfig
 		mockSetup      func(m *mockKafkaClient)
+		publisherSetup func(p *Publisher) // Optional: additional publisher configuration
 		expectedResult Outcome
 		expectedError  string
 		expectCalls    map[string]int // method name -> call count
@@ -718,6 +720,9 @@ func TestProduce(t *testing.T) {
 			mockSetup: func(m *mockKafkaClient) {
 				// No calls expected
 			},
+			publisherSetup: func(p *Publisher) {
+				p.DenyNilPartitionKey = true // Require valid partition keys
+			},
 			expectedResult: Failed,
 			expectedError:  "hash key is empty",
 			expectCalls:    map[string]int{},
@@ -751,6 +756,9 @@ func TestProduce(t *testing.T) {
 			tt.mockSetup(mockClient)
 
 			p := newTestPublisher(tt.dynamicConfig)
+			if tt.publisherSetup != nil {
+				tt.publisherSetup(p)
+			}
 			p.clientMu.Lock()
 			p.client = mockClient
 			p.clientMu.Unlock()


### PR DESCRIPTION
add a configurable option to reject messages without partition keys.  by default they will be published via round robin to kafka partitions, as per normal kafka behavior. 