### PR TITLE
allow a custom prometheus registry to be configured for franz-go

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -605,4 +606,32 @@ func TestToKgoOpts_PrometheusMetrics(t *testing.T) {
 			client.Close()
 		})
 	}
+}
+
+// TestToKgoOpts_CustomPrometheusRegistry verifies a custom Prometheus registry can be configured.
+func TestToKgoOpts_CustomPrometheusRegistry(t *testing.T) {
+	t.Parallel()
+
+	// Create a custom registry
+	customRegistry := prometheus.NewRegistry()
+
+	publisher := &Publisher{
+		Brokers:              []string{"localhost:9092"},
+		PrometheusNamespace:  "test_kafka",
+		PrometheusSubsystem:  "producer",
+		PrometheusRegisterer: customRegistry,
+	}
+
+	opts := publisher.toKgoOpts()
+	require.NotEmpty(t, opts)
+
+	// Should be able to create a client with metrics hook using custom registry
+	client, err := kgo.NewClient(opts...)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer client.Close()
+
+	// The custom registry is configured successfully if the client was created without error.
+	// Metrics are registered when kgo.NewClient is called, but they won't have data until
+	// there's actual Kafka activity (connections, produce, etc.)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xmidt-org/wrp-go/v5"
 	"github.com/xmidt-org/wrpkafka"
 )
@@ -401,4 +402,37 @@ func ExamplePublisher_AddPublishEventListener() {
 
 	fmt.Println("Event listener registered")
 	// Output: Event listener registered
+}
+
+// Example_customPrometheusRegistry demonstrates using a custom Prometheus registry
+// instead of the default registry. This is useful when your application manages
+// its own Prometheus registry and you want all metrics in one place.
+func Example_customPrometheusRegistry() {
+	// Create a custom Prometheus registry for your application
+	customRegistry := prometheus.NewRegistry()
+
+	publisher := &wrpkafka.Publisher{
+		Brokers: []string{"localhost:9092"},
+		InitialDynamicConfig: wrpkafka.DynamicConfig{
+			TopicMap: []wrpkafka.TopicRoute{
+				{Pattern: "*", Topic: "events"},
+			},
+		},
+
+		// Configure Prometheus metrics with custom registry
+		PrometheusNamespace:  "my_app",
+		PrometheusSubsystem:  "kafka",
+		PrometheusRegisterer: customRegistry, // Use custom registry instead of default
+	}
+
+	if err := publisher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer publisher.Stop(context.Background())
+
+	// Now all kafka metrics are registered in customRegistry
+	// You can gather metrics from it with customRegistry.Gather()
+
+	fmt.Println("Custom Prometheus registry configured")
+	// Output: Custom Prometheus registry configured
 }

--- a/publisher.go
+++ b/publisher.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/plugin/kprom"
@@ -126,6 +127,16 @@ type Publisher struct {
 	// Only used when PrometheusNamespace is set.
 	// Optional. Default: "" (no subsystem).
 	PrometheusSubsystem string
+
+	// PrometheusRegisterer is a custom Prometheus registerer to use for metrics.
+	// If nil, the default Prometheus registry is used.
+	// Only used when PrometheusNamespace is set.
+	// Optional. Default: nil (uses default registry).
+	PrometheusRegisterer interface {
+		Register(prometheus.Collector) error
+		MustRegister(...prometheus.Collector)
+		Unregister(prometheus.Collector) bool
+	}
 
 	// DenyNilPartitionKey requires valid partition keys and fails publishing when the hash key
 	// cannot be extracted from the message (missing or empty).
@@ -649,6 +660,9 @@ func (p *Publisher) toKgoOpts() []kgo.Opt {
 		var metricsOpts []kprom.Opt
 		if p.PrometheusSubsystem != "" {
 			metricsOpts = append(metricsOpts, kprom.Subsystem(p.PrometheusSubsystem))
+		}
+		if p.PrometheusRegisterer != nil {
+			metricsOpts = append(metricsOpts, kprom.Registerer(p.PrometheusRegisterer))
 		}
 		metrics := kprom.NewMetrics(p.PrometheusNamespace, metricsOpts...)
 		opts = append(opts, kgo.WithHooks(metrics))


### PR DESCRIPTION
touchstone uses a custom registry so we need to use the same one in franz-go in order to see any internal metrics