### PR TITLE
add options for record retries

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - bodyclose
     - dupl
     - errorlint
-    - goconst
     - gosec
     - misspell
     - prealloc

--- a/cleanup_timeout_test.go
+++ b/cleanup_timeout_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
+const testBrokerCleanup = "localhost:9092"
+
 // captureFlushClient captures the context passed to Flush for testing.
 type captureFlushClient struct {
 	capturedCtx *context.Context
@@ -88,7 +90,7 @@ func TestStop_CleanupTimeoutRespectsCaller(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := &Publisher{}
-			p.Brokers = []string{"localhost:9092"}
+			p.Brokers = []string{testBrokerCleanup}
 			p.CleanupTimeout = tt.cleanupTimeout
 			p.InitialDynamicConfig = DynamicConfig{
 				TopicMap: []TopicRoute{{Pattern: "*", Topic: "test"}},

--- a/config_test.go
+++ b/config_test.go
@@ -481,9 +481,10 @@ func TestToKgoOpts(t *testing.T) {
 		{
 			name: "timeouts and retries",
 			publisher: &Publisher{
-				Brokers:        []string{"localhost:9092"},
-				RequestTimeout: 30 * time.Second,
-				MaxRetries:     5,
+				Brokers:           []string{"localhost:9092"},
+				RequestTimeout:    30 * time.Second,
+				MaxRequestRetries: 5,
+				MaxRecordRetries:  5,
 			},
 		},
 		{
@@ -534,7 +535,8 @@ func TestToKgoOpts(t *testing.T) {
 				MaxBufferedRecords:     1000,
 				MaxBufferedBytes:       1024 * 1024,
 				RequestTimeout:         30 * time.Second,
-				MaxRetries:             5,
+				MaxRequestRetries:      5,
+				MaxRecordRetries:       5,
 				AllowAutoTopicCreation: true,
 			},
 		},
@@ -558,7 +560,8 @@ func TestToKgoOpts_CreatesValidClient(t *testing.T) {
 		Brokers:            []string{"localhost:9092"},
 		MaxBufferedRecords: 1000,
 		RequestTimeout:     30 * time.Second,
-		MaxRetries:         5,
+		MaxRequestRetries:  5,
+		MaxRecordRetries:   5,
 	}
 
 	opts := publisher.toKgoOpts()

--- a/errors.go
+++ b/errors.go
@@ -5,34 +5,45 @@ package wrpkafka
 
 import "errors"
 
+// Error type constants for metrics
+const (
+	errorTypeEncoding   = "encoding_error"
+	errorTypeNoMatch    = "no_topic_match"
+	errorTypeBuffer     = "buffer_full"
+	errorTypeBroker     = "broker_error"
+	errorTypeTimeout    = "timeout"
+	errorTypeValidation = "validation_error"
+	errorTypeNotStarted = "not_started"
+)
+
 var (
 	// ErrEncoding indicates msgpack encoding failed.
 	ErrEncoding = &metricError{
-		metric:  "encoding_error",
+		metric:  errorTypeEncoding,
 		message: "encoding failed",
 	}
 
 	// ErrNoTopicMatch indicates no routing rule matched the event type.
 	ErrNoTopicMatch = &metricError{
-		metric:  "no_topic_match",
+		metric:  errorTypeNoMatch,
 		message: "no topic matched",
 	}
 
 	// ErrBufferFull indicates buffer capacity exceeded (QoS 0-24 only).
 	ErrBufferFull = &metricError{
-		metric:  "buffer_full",
+		metric:  errorTypeBuffer,
 		message: "buffer full",
 	}
 
 	// ErrBroker indicates Kafka broker rejected the message.
 	ErrBroker = &metricError{
-		metric:  "broker_error",
+		metric:  errorTypeBroker,
 		message: "broker error",
 	}
 
 	// ErrTimeout indicates request timeout exceeded.
 	ErrTimeout = &metricError{
-		metric:  "timeout",
+		metric:  errorTypeTimeout,
 		message: "timeout",
 	}
 
@@ -44,13 +55,13 @@ var (
 
 	// ErrValidation indicates configuration validation failed.
 	ErrValidation = &metricError{
-		metric:  "validation_error",
+		metric:  errorTypeValidation,
 		message: "validation error",
 	}
 
 	// ErrNotStarted indicates the publisher has not been started.
 	ErrNotStarted = &metricError{
-		metric:  "not_started",
+		metric:  errorTypeNotStarted,
 		message: "publisher not started",
 	}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -59,7 +59,7 @@ func TestErrors(t *testing.T) {
 			err      error
 			expected string
 		}{
-			{"encoding error", ErrEncoding, "encoding_error"},
+			{"encoding error", ErrEncoding, errorTypeEncoding},
 			{"no topic match", ErrNoTopicMatch, "no_topic_match"},
 			{"buffer full", ErrBufferFull, "buffer_full"},
 			{"broker error", ErrBroker, "broker_error"},
@@ -68,7 +68,7 @@ func TestErrors(t *testing.T) {
 			{"not started", ErrNotStarted, "not_started"},
 			{"nil error", nil, ""},
 			{"unknown error", fmt.Errorf("random"), "unknown"},
-			{"wrapped encoding", errors.Join(ErrEncoding, fmt.Errorf("test")), "encoding_error"},
+			{"wrapped encoding", errors.Join(ErrEncoding, fmt.Errorf("test")), errorTypeEncoding},
 		}
 
 		for _, tt := range tests {

--- a/example_test.go
+++ b/example_test.go
@@ -63,11 +63,13 @@ func ExamplePublisher() {
 		MaxBufferedBytes:   10 * 1024 * 1024, // 10 MB
 
 		// Timeouts (optional - 0 means no timeout)
-		RequestTimeout: 30 * 1000000000, // 30 seconds (time.Duration)
-		CleanupTimeout: 5 * 1000000000,  // 5 seconds
+		RequestTimeout:        30 * 1000000000, // 30 seconds (time.Duration)
+		RecordDeliveryTimeout: 60 * 1000000000, // 60 seconds - max time record can remain buffered
+		CleanupTimeout:        5 * 1000000000,  // 5 seconds
 
-		// Retry behavior (optional - 0 means fail fast)
-		MaxRetries: 3,
+		// Retry behavior (optional)
+		MaxRequestRetries: 3, // Retry individual requests up to 3 times
+		MaxRecordRetries:  3, // Retry records up to 3 times (0 = unlimited)
 
 		// Topic routing configuration
 		InitialDynamicConfig: wrpkafka.DynamicConfig{

--- a/hash_key_provider_test.go
+++ b/hash_key_provider_test.go
@@ -90,7 +90,7 @@ func (s *HashKeyProviderSuite) TestParseHashKey_Invalid() {
 // GetHashKey tests
 func (s *HashKeyProviderSuite) TestGetHashKey_None() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
 	hashKey := HashKey{Name: HashKeyNone}
 	key, err := hashKey.GetHashKey(msg)
@@ -100,9 +100,9 @@ func (s *HashKeyProviderSuite) TestGetHashKey_None() {
 
 func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Valid() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "mac:112233445566", key)
@@ -120,7 +120,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_CustomField() {
 
 func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_DefaultWhenEmpty() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
 	hashKey := HashKey{} // Empty struct should default to metadata/hw-deviceid
 	key, err := hashKey.GetHashKey(msg)
@@ -132,7 +132,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_NilMetadata() {
 	msg := &wrp.Message{
 		Metadata: nil,
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
@@ -141,9 +141,9 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_NilMetadata() {
 
 func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_EmptyValue() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": ""},
+		Metadata: map[string]string{DefaultMetadataKeyField: ""},
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
@@ -154,7 +154,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_MissingField() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"other-field": "value"},
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
@@ -165,7 +165,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Valid_LeadingSlash() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"/hw-deviceid": "mac:112233445566"},
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "mac:112233445566", key)
@@ -175,7 +175,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Empty_LeadingSlash() {
 	msg := &wrp.Message{
 		Metadata: map[string]string{"/hw-deviceid": ""},
 	}
-	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrEmptyHashKey))
@@ -184,7 +184,7 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_Empty_LeadingSlash() {
 
 func (s *HashKeyProviderSuite) TestGetHashKey_Metadata_EmptyFieldName() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
 	hashKey := HashKey{Name: HashKeyMetadata, MetadataField: ""}
 	key, err := hashKey.GetHashKey(msg)
@@ -227,9 +227,9 @@ func (s *HashKeyProviderSuite) TestGetHashKey_Source_InvalidFormat() {
 
 func (s *HashKeyProviderSuite) TestGetHashKey_InvalidKeyType() {
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
-	hashKey := HashKey{Name: HashKeyType("invalid"), MetadataField: "hw-deviceid"}
+	hashKey := HashKey{Name: HashKeyType("invalid"), MetadataField: DefaultMetadataKeyField}
 	key, err := hashKey.GetHashKey(msg)
 	assert.Error(s.T(), err)
 	assert.True(s.T(), errors.Is(err, ErrInvalidHashKeyType))
@@ -242,7 +242,7 @@ func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_Metadata() {
 	assert.NoError(s.T(), err)
 
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
 	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)
@@ -278,7 +278,7 @@ func (s *HashKeyProviderSuite) TestIntegration_ParseAndExtract_Default() {
 	assert.NoError(s.T(), err)
 
 	msg := &wrp.Message{
-		Metadata: map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata: map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 	}
 	key, err := hashKey.GetHashKey(msg)
 	assert.NoError(s.T(), err)

--- a/header.go
+++ b/header.go
@@ -10,6 +10,25 @@ import (
 	"github.com/xmidt-org/wrp-go/v5"
 )
 
+// Field name constants for WRP message fields
+const (
+	fieldType                    = "Type"
+	fieldSource                  = "Source"
+	fieldDestination             = "Destination"
+	fieldTransactionUUID         = "TransactionUUID"
+	fieldContentType             = "ContentType"
+	fieldAccept                  = "Accept"
+	fieldStatus                  = "Status"
+	fieldRequestDeliveryResponse = "RequestDeliveryResponse"
+	fieldHeaders                 = "Headers"
+	fieldPath                    = "Path"
+	fieldServiceName             = "ServiceName"
+	fieldURL                     = "URL"
+	fieldPartnerIDs              = "PartnerIDs"
+	fieldSessionID               = "SessionID"
+	fieldQualityOfService        = "QualityOfService"
+)
+
 // extractWRPField extracts field values from a WRP message for use in Kafka record headers.
 // Supports three categories of field extraction:
 //
@@ -90,9 +109,9 @@ func extractWRPField(msg *wrp.Message, fieldName string) []string {
 //   - "Status" (when nil) → nil (but returns true for "ok" flag)
 func extractStandardFields(msg *wrp.Message, fieldName string) ([]string, bool) {
 	switch fieldName {
-	case "Type":
+	case fieldType:
 		return []string{msg.Type.String()}, true
-	case "Source":
+	case fieldSource:
 		return []string{msg.Source}, true
 	case "DeviceID":
 		deviceID, err := wrp.ParseDeviceID(msg.Source)
@@ -100,37 +119,37 @@ func extractStandardFields(msg *wrp.Message, fieldName string) ([]string, bool) 
 			return nil, true
 		}
 		return []string{deviceID.ID()}, true
-	case "Destination":
+	case fieldDestination:
 		return []string{msg.Destination}, true
-	case "TransactionUUID":
+	case fieldTransactionUUID:
 		return []string{msg.TransactionUUID}, true
-	case "ContentType":
+	case fieldContentType:
 		return []string{msg.ContentType}, true
-	case "Accept":
+	case fieldAccept:
 		return []string{msg.Accept}, true
-	case "Status":
+	case fieldStatus:
 		if msg.Status != nil {
 			return []string{strconv.FormatInt(*msg.Status, 10)}, true
 		}
 		return nil, true
-	case "RequestDeliveryResponse":
+	case fieldRequestDeliveryResponse:
 		if msg.RequestDeliveryResponse != nil {
 			return []string{strconv.FormatInt(*msg.RequestDeliveryResponse, 10)}, true
 		}
 		return nil, true
-	case "Headers":
+	case fieldHeaders:
 		return msg.Headers, true
-	case "Path":
+	case fieldPath:
 		return []string{msg.Path}, true
-	case "ServiceName":
+	case fieldServiceName:
 		return []string{msg.ServiceName}, true
-	case "URL":
+	case fieldURL:
 		return []string{msg.URL}, true
-	case "PartnerIDs":
+	case fieldPartnerIDs:
 		return msg.PartnerIDs, true
-	case "SessionID":
+	case fieldSessionID:
 		return []string{msg.SessionID}, true
-	case "QualityOfService":
+	case fieldQualityOfService:
 		return []string{strconv.Itoa(int(msg.QualityOfService))}, true
 	}
 
@@ -232,22 +251,22 @@ func extractMetadataFields(msg *wrp.Message, fieldName string) ([]string, bool) 
 // validWRPFieldNames contains all valid WRP field names for header extraction.
 // This is used for validation to catch typos and invalid field references early.
 var validWRPFieldNames = map[string]struct{}{
-	"Type":                    {},
-	"Source":                  {},
-	"DeviceID":                {},
-	"Destination":             {},
-	"TransactionUUID":         {},
-	"ContentType":             {},
-	"Accept":                  {},
-	"Status":                  {},
-	"RequestDeliveryResponse": {},
-	"Headers":                 {},
-	"Path":                    {},
-	"ServiceName":             {},
-	"URL":                     {},
-	"PartnerIDs":              {},
-	"SessionID":               {},
-	"QualityOfService":        {},
+	fieldType:                    {},
+	fieldSource:                  {},
+	"DeviceID":                   {},
+	fieldDestination:             {},
+	fieldTransactionUUID:         {},
+	fieldContentType:             {},
+	fieldAccept:                  {},
+	fieldStatus:                  {},
+	fieldRequestDeliveryResponse: {},
+	fieldHeaders:                 {},
+	fieldPath:                    {},
+	fieldServiceName:             {},
+	fieldURL:                     {},
+	fieldPartnerIDs:              {},
+	fieldSessionID:               {},
+	fieldQualityOfService:        {},
 }
 
 // isValidWRPFieldReference validates a wrp.* header field reference.

--- a/integration_helpers_test.go
+++ b/integration_helpers_test.go
@@ -49,12 +49,14 @@ func setupKafka(t *testing.T) (*kafka.KafkaContainer, string) {
 	configureTestContainersForPodman(t)
 
 	// Start Kafka container
-	// Using port-based wait strategy instead of log parsing for reliability
+	// Using only port-based wait strategy (no log parsing) for parallel test reliability
 	kafkaContainer, err := kafka.Run(ctx,
 		"confluentinc/confluent-local:7.8.0",
 		kafka.WithClusterID("test-cluster"),
-		testcontainers.WithWaitStrategy(
-			wait.ForListeningPort("9093/tcp").WithStartupTimeout(90*time.Second),
+		// Override default wait strategies with port-only check
+		testcontainers.WithWaitStrategyAndDeadline(
+			90*time.Second,
+			wait.ForListeningPort("9093/tcp"),
 		),
 	)
 	require.NoError(t, err, "Failed to start Kafka container")

--- a/outcome.go
+++ b/outcome.go
@@ -31,19 +31,28 @@ const (
 	Failed
 )
 
+// Outcome string constants
+const (
+	outcomeAccepted  = "Accepted"
+	outcomeQueued    = "Queued"
+	outcomeAttempted = "Attempted"
+	outcomeDropped   = "Dropped"
+	outcomeFailed    = "Failed"
+)
+
 // String returns the string representation of the Outcome.
 func (o Outcome) String() string {
 	switch o {
 	case Accepted:
-		return "Accepted"
+		return outcomeAccepted
 	case Queued:
-		return "Queued"
+		return outcomeQueued
 	case Attempted:
-		return "Attempted"
+		return outcomeAttempted
 	case Dropped:
-		return "Dropped"
+		return outcomeDropped
 	case Failed:
-		return "Failed"
+		return outcomeFailed
 	default:
 		return "Unknown"
 	}

--- a/outcome_test.go
+++ b/outcome_test.go
@@ -18,29 +18,29 @@ func TestOutcome_String(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Accepted",
+			name:     outcomeAccepted,
 			outcome:  Accepted,
-			expected: "Accepted",
+			expected: outcomeAccepted,
 		},
 		{
-			name:     "Queued",
+			name:     outcomeQueued,
 			outcome:  Queued,
-			expected: "Queued",
+			expected: outcomeQueued,
 		},
 		{
-			name:     "Attempted",
+			name:     outcomeAttempted,
 			outcome:  Attempted,
-			expected: "Attempted",
+			expected: outcomeAttempted,
 		},
 		{
-			name:     "Dropped",
+			name:     outcomeDropped,
 			outcome:  Dropped,
-			expected: "Dropped",
+			expected: outcomeDropped,
 		},
 		{
-			name:     "Failed",
+			name:     outcomeFailed,
 			outcome:  Failed,
-			expected: "Failed",
+			expected: outcomeFailed,
 		},
 		{
 			name:     "Unknown - invalid outcome value",

--- a/publisher.go
+++ b/publisher.go
@@ -138,11 +138,27 @@ type Publisher struct {
 	// Default: 0 (no timeout).
 	CleanupTimeout time.Duration
 
-	// MaxRetries controls retry behavior on broker failures.
+	// RecordDeliveryTimeout sets the maximum time a record can remain buffered
+	// before timing out. This timeout starts when the record is first buffered.
+	// When exceeded, the record fails and the error callback fires.
+	// Zero or negative values mean no timeout (records can buffer indefinitely).
+	// Default: 0 (no timeout).
+	RecordDeliveryTimeout time.Duration
+
+	// MaxRequestRetries controls retry behavior for individual broker requests.
+	// This applies to network-level request failures (timeouts, connection errors).
 	// <=0: No retries, fail immediately (default).
-	// >0: Retry up to this many times.
+	// >0: Retry each request up to this many times.
 	// Default: 0 (no retries, fail fast).
-	MaxRetries int
+	MaxRequestRetries int
+
+	// MaxRecordRetries controls retry behavior for record-level failures.
+	// This is the maximum number of times Produce() will retry sending a record
+	// (across multiple requests). When retries are exhausted, the error callback fires.
+	// <=0: Retry indefinitely until success, context cancellation, or client closure (default).
+	// >0: Retry up to this many times, then fail and trigger error callback.
+	// Default: 0 (unlimited retries - callbacks never fire with errors).
+	MaxRecordRetries int
 
 	// AllowAutoTopicCreation enables automatic topic creation when publishing to non-existent topics.
 	// Default: false (safer for production - prevents typos from creating topics).
@@ -384,31 +400,22 @@ func (p *Publisher) Produce(ctx context.Context, msg *wrp.Message) (Outcome, err
 
 		if qos <= 24 {
 			// Low QoS: Fire-and-forget with TryProduce
+			// Capture recordEvent in closure to avoid loop variable capture bug
+			evt := recordEvent
 			client.TryProduce(ctx, record, func(r *kgo.Record, err error) {
-				p.dispatchEvent(&recordEvent, startTime, err)
+				p.dispatchEvent(&evt, startTime, err)
 			})
 			returnOutcome = Attempted
 		} else if qos <= 74 {
 			// Medium QoS: Async with retry, block if buffer full
-			// Provide callback to capture async errors (retries exhausted, timeout, etc.)
+			// Callback dispatches event for both success and error cases
+			// Capture recordEvent in closure to avoid loop variable capture bug
+			evt := recordEvent
 			client.Produce(ctx, record, func(r *kgo.Record, err error) {
-				if err != nil {
-					// Async error occurred - dispatch error event
-					// Note: This runs in a different goroutine after the produce attempt
-					asyncEvent := PublishEvent{
-						EventType:          recordEvent.EventType,
-						Topic:              recordEvent.Topic,
-						TopicShardStrategy: recordEvent.TopicShardStrategy,
-						Error:              err,
-						ErrorType:          errorType(err),
-						Duration:           time.Since(startTime),
-					}
-					p.dispatchEvent(&asyncEvent, startTime, err)
-				}
+				// Dispatch event for both success and error
+				// Note: This runs in a different goroutine after the produce attempt
+				p.dispatchEvent(&evt, startTime, err)
 			})
-
-			// Optimistically dispatch success event (actual result delivered via callback)
-			p.dispatchEvent(&recordEvent, startTime, nil)
 			returnOutcome = Queued
 		} else {
 			// High QoS: Sync with confirmation
@@ -646,10 +653,22 @@ func (p *Publisher) toKgoOpts() []kgo.Opt {
 		opts = append(opts, kgo.RequestTimeoutOverhead(p.RequestTimeout))
 	}
 
-	// Add retry config (only if > 0)
-	// <=0 = no retries (fail fast), N = retry N times
-	if p.MaxRetries > 0 {
-		opts = append(opts, kgo.RequestRetries(p.MaxRetries))
+	// Add record delivery timeout (only if > 0)
+	// Controls how long a record can remain buffered before timing out
+	if p.RecordDeliveryTimeout > 0 {
+		opts = append(opts, kgo.RecordDeliveryTimeout(p.RecordDeliveryTimeout))
+	}
+
+	// Add request retry config (only if > 0)
+	// <=0 = no retries (fail fast), N = retry N times per request
+	if p.MaxRequestRetries > 0 {
+		opts = append(opts, kgo.RequestRetries(p.MaxRequestRetries))
+	}
+
+	// Add record retry config (only if > 0)
+	// <=0 = unlimited retries (default), N = retry up to N times then fail
+	if p.MaxRecordRetries > 0 {
+		opts = append(opts, kgo.RecordRetries(p.MaxRecordRetries))
 	}
 
 	// Add linger time

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -815,8 +815,8 @@ func TestProduceAsyncErrors(t *testing.T) {
 			simulatedError:        errors.New("retries exhausted"),
 			expectedResult:        Queued,
 			expectedError:         "",
-			expectedEventCalls:    2, // 1 success + 1 async error
-			expectedSuccessEvents: 1,
+			expectedEventCalls:    1, // 1 async error only
+			expectedSuccessEvents: 0,
 			expectedErrorEvents:   1,
 		},
 		{
@@ -833,8 +833,8 @@ func TestProduceAsyncErrors(t *testing.T) {
 			simulatedError:        context.DeadlineExceeded,
 			expectedResult:        Queued,
 			expectedError:         "",
-			expectedEventCalls:    2, // 1 success + 1 async error
-			expectedSuccessEvents: 1,
+			expectedEventCalls:    1, // 1 async error only
+			expectedSuccessEvents: 0,
 			expectedErrorEvents:   1,
 		},
 		{

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -103,7 +103,7 @@ func TestProduceQoS(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+			Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10, // low QoS
 		}
@@ -125,7 +125,7 @@ func TestProduceQoS(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+			Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 50, // medium QoS
 		}
@@ -161,7 +161,7 @@ func TestProduceQoS(t *testing.T) {
 
 				msg := &wrp.Message{
 					Type:             wrp.SimpleEventMessageType,
-					Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+					Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 					Destination:      "event:test",
 					QualityOfService: wrp.QOSValue(tt.qos),
 				}
@@ -214,7 +214,7 @@ func TestProduceErrors(t *testing.T) {
 
 		msg := &wrp.Message{
 			Destination: "event:test",
-			Metadata:    map[string]string{"hw-deviceid": "mac:112233445566"},
+			Metadata:    map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 		}
 
 		outcome, err := p.Produce(ctx, msg)
@@ -305,7 +305,7 @@ func TestEventListeners(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+			Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10,
 		}
@@ -354,7 +354,7 @@ func TestEventListeners(t *testing.T) {
 
 		msg := &wrp.Message{
 			Type:             wrp.SimpleEventMessageType,
-			Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+			Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 			Destination:      "event:test",
 			QualityOfService: 10,
 		}
@@ -461,7 +461,7 @@ func TestProduceContextCancellation(t *testing.T) {
 
 	msg := &wrp.Message{
 		Type:             wrp.SimpleEventMessageType,
-		Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 		Destination:      "event:test",
 		QualityOfService: 50,
 	}
@@ -484,7 +484,7 @@ func TestProduceNotStarted(t *testing.T) {
 
 	msg := &wrp.Message{
 		Type:             wrp.SimpleEventMessageType,
-		Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+		Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 		Destination:      "event:test",
 		QualityOfService: 50,
 	}
@@ -514,7 +514,7 @@ func TestProduce(t *testing.T) {
 			name: "low QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 10,
 			},
@@ -532,7 +532,7 @@ func TestProduce(t *testing.T) {
 			name: "low QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 0,
 			},
@@ -553,7 +553,7 @@ func TestProduce(t *testing.T) {
 			name: "medium QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -571,7 +571,7 @@ func TestProduce(t *testing.T) {
 			name: "medium QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 74,
 			},
@@ -593,7 +593,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS single topic success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 99,
 			},
@@ -613,7 +613,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS multiple topics success",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 75,
 			},
@@ -636,7 +636,7 @@ func TestProduce(t *testing.T) {
 			name: "high QoS sync failure",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 80,
 			},
@@ -656,7 +656,7 @@ func TestProduce(t *testing.T) {
 			name: "QoS boundary values",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 24, // boundary between low and medium
 			},
@@ -674,7 +674,7 @@ func TestProduce(t *testing.T) {
 			name: "QoS boundary values - 25",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 25, // boundary between low and medium
 			},
@@ -692,7 +692,7 @@ func TestProduce(t *testing.T) {
 			name: "no topic match",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:nomatch",
 				QualityOfService: 50,
 			},
@@ -710,7 +710,7 @@ func TestProduce(t *testing.T) {
 			name: "invalid hash key",
 			msg: &wrp.Message{
 				Type: wrp.SimpleEventMessageType,
-				//Metadata:         map[string]string{"hw-deviceid": "invalid-device-id"},
+				//Metadata:         map[string]string{DefaultMetadataKeyField: "invalid-device-id"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -731,7 +731,7 @@ func TestProduce(t *testing.T) {
 			name: "invalid destination",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "invalid-destination",
 				QualityOfService: 50,
 			},
@@ -805,7 +805,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async retry exhausted error",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 50,
 			},
@@ -823,7 +823,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async timeout error",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 60,
 			},
@@ -841,7 +841,7 @@ func TestProduceAsyncErrors(t *testing.T) {
 			name: "medium QoS single topic - async success (no error)",
 			msg: &wrp.Message{
 				Type:             wrp.SimpleEventMessageType,
-				Metadata:         map[string]string{"hw-deviceid": "mac:112233445566"},
+				Metadata:         map[string]string{DefaultMetadataKeyField: "mac:112233445566"},
 				Destination:      "event:test",
 				QualityOfService: 25,
 			},


### PR DESCRIPTION
there was only an option for request retries for connecting to the broker. the record was retried forever which is why we never saw any errors on the callback.

there was also a closure bug. 

the rest of goconst useless lint stuff